### PR TITLE
Skip failed and timed-out posts instead of retrying indefinitely

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -158,6 +158,9 @@ async def publish_one(config) -> bool:
     if msg_id:
         await mark_as_published(post["reddit_id"], msg_id)
         asyncio.create_task(_publish_comments_delayed(config, post, msg_id))
+    else:
+        logger.warning("Skipping post %s: publish failed", post["reddit_id"])
+        await mark_as_published(post["reddit_id"], 0)
 
     if media_path:
         cleanup(media_path)
@@ -202,6 +205,10 @@ async def main() -> None:
             await asyncio.wait_for(publish_one(config), timeout=300)
         except TimeoutError:
             logger.warning("publish_one timed out after 5 minutes")
+            posts = await get_unpublished_posts(limit=1)
+            if posts:
+                logger.warning("Skipping post %s due to timeout", posts[0]["reddit_id"])
+                await mark_as_published(posts[0]["reddit_id"], 0)
 
         # Wait before next publish tick
         with contextlib.suppress(TimeoutError):


### PR DESCRIPTION
## Summary
- When `publish_post` returns `None` (e.g. `PHOTO_INVALID_DIMENSIONS`), the post is now marked as skipped (`msg_id=0`) instead of staying in the queue and being retried forever
- After a 5-minute `publish_one` timeout, the current pending post is also marked as skipped so the bot moves on instead of hanging

## Root cause
Today the bot was silent from 08:55 to 18:14 (8+ hours). Post `t3_1sln99b` failed with `PHOTO_INVALID_DIMENSIONS` three times (09:10, 09:25, 09:40), then at 10:14 the download hung and triggered the 5-minute timeout. After the timeout the same broken post remained at the head of the queue, causing the event loop to stall.

## Test plan
- [ ] Verify a post with `PHOTO_INVALID_DIMENSIONS` gets skipped after one attempt (check `Skipping post ... publish failed` log)
- [ ] Verify that after a timeout, `Skipping post ... due to timeout` appears and publishing resumes