### PR TITLE
Fix gallery publication losing caption when image count is 11/21/31

### DIFF
--- a/src/publisher/telegram.py
+++ b/src/publisher/telegram.py
@@ -406,6 +406,10 @@ async def _publish_gallery(
 ) -> int | None:
     groups = [media_paths[i : i + MEDIA_GROUP_MAX] for i in range(0, len(media_paths), MEDIA_GROUP_MAX)]
 
+    # sendMediaGroup requires 2-10 items. If trailing group has 1 item, steal one from the previous group.
+    if len(groups) > 1 and len(groups[-1]) == 1:
+        groups[-1].insert(0, groups[-2].pop())
+
     for group in groups[:-1]:
         await _send_media_group(client, config, group, caption=None)
 


### PR DESCRIPTION
## Summary

When a Reddit gallery has 11, 21, 31… images, `_publish_gallery` splits paths into chunks of 10 and ends up with a trailing group of size 1. Telegram's `sendMediaGroup` requires 2–10 items, so that final call returned 400, and the caption attached to it (title + footer with source links) was lost. The user sees the first 10-image album but no continuation message and no footer.

## Fix

If the trailing group ends up with a single item, move one item back from the previous group so both groups stay valid `sendMediaGroup` payloads (e.g., `[10, 1]` → `[9, 2]`).

## Test plan

- [x] Existing publisher tests pass (`uv run pytest tests/test_publisher.py`)
- [ ] Verify on a real 11+ image gallery once the bot is running again