### PR TITLE
Handle Telegram 429 on sendMediaGroup

### DIFF
--- a/src/publisher/telegram.py
+++ b/src/publisher/telegram.py
@@ -1,3 +1,4 @@
+import asyncio
 import html as _html
 import io
 import json
@@ -340,13 +341,20 @@ async def _send_media_group(
             entry["parse_mode"] = "HTML"
         media.append(entry)
 
-    response = await client.post(
-        _api_url(config.telegram_bot_token, "sendMediaGroup"),
-        data={"chat_id": config.telegram_chat_id, "media": json.dumps(media)},
-        files=files,
-    )
-    if response.status_code == 200:
-        return response.json()["result"][0]["message_id"]
+    for attempt in range(3):
+        response = await client.post(
+            _api_url(config.telegram_bot_token, "sendMediaGroup"),
+            data={"chat_id": config.telegram_chat_id, "media": json.dumps(media)},
+            files=files,
+        )
+        if response.status_code == 200:
+            return response.json()["result"][0]["message_id"]
+        if response.status_code == 429:
+            retry_after = response.json().get("parameters", {}).get("retry_after", 5)
+            logger.info("sendMediaGroup rate-limited, sleeping %ds (attempt %d)", retry_after, attempt + 1)
+            await asyncio.sleep(retry_after + 1)
+            continue
+        break
     logger.warning("sendMediaGroup failed: %s", response.text)
     return None
 
@@ -412,6 +420,7 @@ async def _publish_gallery(
 
     for group in groups[:-1]:
         await _send_media_group(client, config, group, caption=None)
+        await asyncio.sleep(3)
 
     return await _send_media_group(client, config, groups[-1], caption=caption)
 


### PR DESCRIPTION
## Summary

Multi-batch gallery posts (>10 images) were losing the second batch — and with it the caption containing title + footer links. Production log:

```
22:25:51 sendMediaGroup #1 (10 photos)        → 200 OK
22:25:56 sendMediaGroup #2 (8 photos+caption) → 429 retry after 5
22:25:56 Failed to publish post t3_1ta37ga
```

`_send_media_group` returned `None` on 429 without retrying, so the second album never sent and `_publish_gallery` reported failure.

## Fix

- `_send_media_group`: on 429, sleep for `retry_after` (+1s safety margin) and retry, up to 3 attempts.
- `_publish_gallery`: `asyncio.sleep(3)` between consecutive groups to preempt hitting the limit in the first place.

## Test plan

- [x] `uv run pytest tests/test_publisher.py` — 8 passed
- [ ] Verify on next gallery with >10 images that survives downloads (the original failing post will be re-marked unpublished after this deploys)