### PR TITLE
Reduce inter-group gallery pause to 1s

### DIFF
--- a/src/publisher/telegram.py
+++ b/src/publisher/telegram.py
@@ -420,7 +420,7 @@ async def _publish_gallery(
 
     for group in groups[:-1]:
         await _send_media_group(client, config, group, caption=None)
-        await asyncio.sleep(3)
+        await asyncio.sleep(1)
 
     return await _send_media_group(client, config, groups[-1], caption=caption)
 


### PR DESCRIPTION
## Summary

3s preemptive pause between `sendMediaGroup` calls felt noticeably long in the channel (user-visible gap ~11s for an 18-image gallery). Drop to 1s. The 429 retry path in `_send_media_group` (PR #40) still handles bursts if Telegram pushes back.

## Test plan

- [x] `uv run pytest tests/test_publisher.py` — 8 passed
- [ ] Next multi-batch gallery: gap should be ~9s; if any 429 retries appear in logs, consider bumping back up