### PR TITLE
Expire posts older than 24h

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       POSTGRES_DB: reddit_scrapper
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/src/db.py
+++ b/src/db.py
@@ -156,6 +156,17 @@ async def get_post(reddit_id: str) -> dict | None:
         return post
 
 
+async def delete_old_posts() -> int:
+    async with _pool.acquire() as conn:
+        result = await conn.execute(
+            "DELETE FROM posts WHERE created_utc < NOW() - INTERVAL '24 hours'"
+        )
+    deleted = int(result.split()[-1])
+    if deleted:
+        logger.info("Deleted %d posts older than 24h", deleted)
+    return deleted
+
+
 async def get_explanation(reddit_id: str) -> str | None:
     async with _pool.acquire() as conn:
         row = await conn.fetchrow("SELECT ai_explanation FROM posts WHERE reddit_id = $1", reddit_id)

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ import httpx
 from src.config import load_config
 from src.db import (
     close_db,
+    delete_old_posts,
     get_unpublished_posts,
     init_db,
     insert_post,
@@ -47,16 +48,24 @@ def _is_video_url(url: str) -> bool:
     return any(d in netloc for d in _VIDEO_DOMAINS)
 
 
+_MAX_POST_AGE_HOURS = 24
+
+
 async def scrape_new_posts(config) -> None:
     """Fetch Reddit and store new posts in DB."""
     started_at = datetime.now(UTC)
     posts_found = posts_new = 0
     error = None
     try:
+        await delete_old_posts()
         posts = await fetch_top_posts(config)
         posts_found = len(posts)
+        cutoff = datetime.now(UTC).timestamp() - _MAX_POST_AGE_HOURS * 3600
         for post in posts:
             if config.skip_nsfw and post["is_nsfw"]:
+                continue
+            post_ts = datetime.fromisoformat(post["created_utc"]).timestamp()
+            if post_ts < cutoff:
                 continue
             if await is_post_exists(post["reddit_id"]):
                 continue


### PR DESCRIPTION
## Summary
- Skip posts older than 24h during scraping (filter by `created_utc` before insert)
- Delete posts older than 24h from DB at the start of each scrape cycle
- Expose postgres port 5432 in docker-compose for local development

## Test plan
- [ ] Verify `delete_old_posts()` logs deleted count on next scrape
- [ ] Confirm no posts with `created_utc < now - 24h` remain in DB after scrape