### PR TITLE
Publish only posts younger than 24h

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -100,7 +100,7 @@ async def insert_post(post: dict) -> None:
 
 
 async def get_unpublished_posts(limit: int | None = None) -> list[dict]:
-    query = "SELECT * FROM posts WHERE published_to_tg = FALSE ORDER BY score DESC"
+    query = "SELECT * FROM posts WHERE published_to_tg = FALSE AND created_utc > NOW() - INTERVAL '24 hours' ORDER BY score DESC"
     if limit:
         query += f" LIMIT {limit}"
     async with _pool.acquire() as conn:
@@ -154,17 +154,6 @@ async def get_post(reddit_id: str) -> dict | None:
         if post.get("media_urls"):
             post["media_urls"] = json.loads(post["media_urls"])
         return post
-
-
-async def delete_old_posts() -> int:
-    async with _pool.acquire() as conn:
-        result = await conn.execute(
-            "DELETE FROM posts WHERE created_utc < NOW() - INTERVAL '24 hours'"
-        )
-    deleted = int(result.split()[-1])
-    if deleted:
-        logger.info("Deleted %d posts older than 24h", deleted)
-    return deleted
 
 
 async def get_explanation(reddit_id: str) -> str | None:

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,6 @@ import httpx
 from src.config import load_config
 from src.db import (
     close_db,
-    delete_old_posts,
     get_unpublished_posts,
     init_db,
     insert_post,
@@ -48,24 +47,16 @@ def _is_video_url(url: str) -> bool:
     return any(d in netloc for d in _VIDEO_DOMAINS)
 
 
-_MAX_POST_AGE_HOURS = 24
-
-
 async def scrape_new_posts(config) -> None:
     """Fetch Reddit and store new posts in DB."""
     started_at = datetime.now(UTC)
     posts_found = posts_new = 0
     error = None
     try:
-        await delete_old_posts()
         posts = await fetch_top_posts(config)
         posts_found = len(posts)
-        cutoff = datetime.now(UTC).timestamp() - _MAX_POST_AGE_HOURS * 3600
         for post in posts:
             if config.skip_nsfw and post["is_nsfw"]:
-                continue
-            post_ts = datetime.fromisoformat(post["created_utc"]).timestamp()
-            if post_ts < cutoff:
                 continue
             if await is_post_exists(post["reddit_id"]):
                 continue
@@ -232,7 +223,7 @@ async def main() -> None:
         "Bot started — publish every %.0fs, scrape every %ds", config.pause_between_posts, config.scrape_interval
     )
 
-    last_scrape: float = 0.0
+    last_scrape: float = float("-inf")
 
     while not stop_event.is_set():
         now = time.monotonic()


### PR DESCRIPTION
## Summary
- Filter published posts by age: only posts with \`created_utc > NOW() - 24h\` are picked for publishing
- Posts remain in DB indefinitely so AI-explanation always works for published content
- Scrape always runs on startup (\`last_scrape = float("-inf")\` fix)

## Test plan
- [ ] Verify no posts older than 24h appear in Telegram channel
- [ ] Verify AI-explanation works on published posts