### PR TITLE
Add Cloudflare Worker proxy for Reddit API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 TELEGRAM_CHAT_ID=your_chat_id_here
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_PROXY_URL=https://your-worker.workers.dev
+REDDIT_PROXY_SECRET=your_secret_token
 REDDIT_USER_AGENT=reddit-scrapper/0.1 (by u/your_username)
 SCRAPE_INTERVAL=1200
 POSTS_LIMIT=50

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,0 +1,26 @@
+export default {
+  async fetch(request, env) {
+    const secret = request.headers.get("X-Proxy-Secret");
+    if (!secret || secret !== env.PROXY_SECRET) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const url = new URL(request.url);
+    const redditUrl = new URL("https://www.reddit.com" + url.pathname);
+    url.searchParams.forEach((value, key) => redditUrl.searchParams.set(key, value));
+
+    const response = await fetch(redditUrl.toString(), {
+      headers: {
+        "User-Agent": env.USER_AGENT || "reddit-scrapper/0.1",
+        "Accept": "application/json",
+        "Accept-Language": "en-US,en;q=0.9",
+      },
+    });
+
+    const body = await response.text();
+    return new Response(body, {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+};

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,10 @@ class Config:
     telegram_chat_id: str
     database_url: str
     gemini_api_key: str | None = None
+    reddit_client_id: str | None = None
+    reddit_client_secret: str | None = None
+    reddit_proxy_url: str | None = None
+    reddit_proxy_secret: str | None = None
     reddit_user_agent: str = "reddit-scrapper/0.1 (by u/your_username)"
     scrape_interval: int = 1200  # seconds (20 minutes)
     posts_limit: int = 50
@@ -49,6 +53,10 @@ def load_config() -> Config:
         telegram_chat_id=chat_id,
         database_url=database_url,
         gemini_api_key=os.getenv("GEMINI_API_KEY") or None,
+        reddit_client_id=os.getenv("REDDIT_CLIENT_ID") or None,
+        reddit_client_secret=os.getenv("REDDIT_CLIENT_SECRET") or None,
+        reddit_proxy_url=os.getenv("REDDIT_PROXY_URL") or None,
+        reddit_proxy_secret=os.getenv("REDDIT_PROXY_SECRET") or None,
         reddit_user_agent=os.getenv("REDDIT_USER_AGENT", "reddit-scrapper/0.1 (by u/your_username)"),
         scrape_interval=int(os.getenv("SCRAPE_INTERVAL", "1200")),
         posts_limit=int(os.getenv("POSTS_LIMIT", "50")),

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -1,6 +1,7 @@
 import asyncio
 import html as _html
 import logging
+import time
 from datetime import UTC, datetime
 
 import httpx
@@ -10,6 +11,29 @@ from src.config import Config
 logger = logging.getLogger(__name__)
 
 REDDIT_URL = "https://www.reddit.com/.json"
+REDDIT_OAUTH_URL = "https://oauth.reddit.com/.json"
+
+_oauth_token: str | None = None
+_oauth_token_expires: float = 0.0
+
+
+async def _get_oauth_token(config: Config) -> str:
+    global _oauth_token, _oauth_token_expires
+    if _oauth_token and time.monotonic() < _oauth_token_expires - 60:
+        return _oauth_token
+    async with httpx.AsyncClient(timeout=15) as client:
+        response = await client.post(
+            "https://www.reddit.com/api/v1/access_token",
+            auth=(config.reddit_client_id, config.reddit_client_secret),
+            data={"grant_type": "client_credentials"},
+            headers={"User-Agent": config.reddit_user_agent},
+        )
+        response.raise_for_status()
+    data = response.json()
+    _oauth_token = data["access_token"]
+    _oauth_token_expires = time.monotonic() + data["expires_in"]
+    logger.info("Reddit OAuth token acquired, expires in %ds", data["expires_in"])
+    return _oauth_token
 
 
 def _detect_post_type(data: dict) -> str:
@@ -81,8 +105,18 @@ async def fetch_top_posts(config: Config) -> list[dict]:
         "Accept-Language": "en-US,en;q=0.9",
     }
 
+    if config.reddit_proxy_url and config.reddit_proxy_secret:
+        url = config.reddit_proxy_url.rstrip("/") + "/.json"
+        headers["X-Proxy-Secret"] = config.reddit_proxy_secret
+    elif config.reddit_client_id and config.reddit_client_secret:
+        token = await _get_oauth_token(config)
+        headers["Authorization"] = f"Bearer {token}"
+        url = REDDIT_OAUTH_URL
+    else:
+        url = REDDIT_URL
+
     async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-        response = await client.get(REDDIT_URL, params=params, headers=headers)
+        response = await client.get(url, params=params, headers=headers)
         response.raise_for_status()
 
     children = response.json().get("data", {}).get("children", [])


### PR DESCRIPTION
## Summary
- Cloudflare Worker (`cloudflare/worker.js`) proxies Reddit API requests through Cloudflare IP, bypassing Railway IP block
- Bot uses proxy if `REDDIT_PROXY_URL` + `REDDIT_PROXY_SECRET` are set; falls back to OAuth or direct otherwise
- Added `REDDIT_PROXY_URL` and `REDDIT_PROXY_SECRET` to config

## Setup
1. Deploy `cloudflare/worker.js` to Cloudflare Workers
2. Set `PROXY_SECRET` and `USER_AGENT` in Worker environment variables
3. Add `REDDIT_PROXY_URL` and `REDDIT_PROXY_SECRET` to Railway environment variables