### PR TITLE
Fix missing audio in videos by refreshing HLS URL before download

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,7 @@ from src.scraper.media import (
     download_video,
     download_video_direct,
 )
-from src.scraper.reddit import fetch_top_comments, fetch_top_posts
+from src.scraper.reddit import fetch_fresh_hls_url, fetch_top_comments, fetch_top_posts
 from src.webapp.server import start_webapp_task
 
 logging.basicConfig(
@@ -138,7 +138,8 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
             await mark_as_published(post["reddit_id"], 0)
             return False
     elif post["post_type"] == "video" and post.get("video_url"):
-        media_path = await download_video_direct(post["video_url"], hls_url=post.get("hls_url"))
+        hls_url = await fetch_fresh_hls_url(config, post["reddit_id"]) or post.get("hls_url")
+        media_path = await download_video_direct(post["video_url"], hls_url=hls_url)
         if media_path:
             media_path = await asyncio.get_event_loop().run_in_executor(None, compress_video, media_path)
         if media_path is None:

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -183,3 +183,34 @@ async def fetch_top_comments(config: Config, post: dict, limit: int = 5) -> list
     except Exception:
         logger.warning("Failed to fetch comments for %s", post["reddit_id"], exc_info=True)
         return []
+
+
+async def fetch_fresh_hls_url(config: Config, reddit_id: str) -> str | None:
+    """Fetch a fresh HLS URL for a Reddit video post (auth token may have expired)."""
+    post_id = reddit_id.removeprefix("t3_")
+    headers = {
+        "User-Agent": config.reddit_user_agent,
+        "Accept": "application/json",
+    }
+    if config.reddit_proxy_url and config.reddit_proxy_secret:
+        url = f"{config.reddit_proxy_url.rstrip('/')}/comments/{post_id}.json"
+        headers["X-Proxy-Secret"] = config.reddit_proxy_secret
+    else:
+        url = f"https://www.reddit.com/comments/{post_id}.json"
+
+    try:
+        async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+            response = await client.get(url, params={"raw_json": 1, "limit": 1}, headers=headers)
+            response.raise_for_status()
+        data = response.json()
+        post_data = data[0]["data"]["children"][0]["data"]
+        hls_url = (
+            (post_data.get("media") or {}).get("reddit_video", {}).get("hls_url")
+            or (post_data.get("secure_media") or {}).get("reddit_video", {}).get("hls_url")
+        )
+        if hls_url:
+            logger.info("Refreshed HLS URL for %s", reddit_id)
+        return hls_url
+    except Exception:
+        logger.debug("Could not refresh HLS URL for %s", reddit_id, exc_info=True)
+        return None


### PR DESCRIPTION
## Summary
Reddit's HLS auth tokens expire hours after scraping. By the time the bot publishes a video post, the stored HLS URL token is stale — yt-dlp fails and falls back to video-only download (no audio).

Fix: fetch a fresh HLS URL from Reddit (via Cloudflare Worker if configured) immediately before downloading each video post.

## Changes
- `src/scraper/reddit.py` — add `fetch_fresh_hls_url(config, reddit_id)`: fetches current post data and extracts a fresh HLS URL with a valid auth token
- `src/main.py` — call `fetch_fresh_hls_url` before `download_video_direct` for video posts; falls back to stored URL if refresh fails

## Test plan
- [ ] Verify next video post in Telegram channel has audio
- [ ] Check Railway logs for "Refreshed HLS URL" messages