### PR TITLE
Skip cached AI explanations shorter than 50 chars

### DIFF
--- a/src/webapp/server.py
+++ b/src/webapp/server.py
@@ -181,7 +181,7 @@ def create_app(config: Config) -> FastAPI:
 
         async def event_stream():
             cached = await get_explanation(reddit_id)
-            if cached:
+            if cached and len(cached) >= 50:
                 yield sse("chunk", cached)
                 yield sse("done", "")
                 return


### PR DESCRIPTION
## Summary
If Gemini stream is interrupted, a truncated explanation (e.g. "Автор поста") gets cached permanently. Fix: treat cached explanations under 50 chars as invalid and regenerate.