### PR TITLE
Fix text post split markers and truncated AI explanation caching

### DIFF
--- a/src/publisher/telegram.py
+++ b/src/publisher/telegram.py
@@ -395,13 +395,20 @@ async def _publish_text_messages(
         raw_chunks = [""]
 
     msg_id = None
+    last = len(raw_chunks) - 1
     for i, raw_chunk in enumerate(raw_chunks):
         chunk_html = _md_to_telegram_html(raw_chunk)
-        text = f"{title_html}\n\n{chunk_html}" if i == 0 else chunk_html
-        if i == len(raw_chunks) - 1:
-            text += f"\n\n{footer}"
-        is_last = i == len(raw_chunks) - 1
-        msg_id = await _send_message(client, config, text, reply_markup=reply_markup if is_last else None)
+        if i == 0:
+            text = f"{title_html}\n\n{chunk_html}"
+            if i == last:
+                text += f"\n\n{footer}"
+            else:
+                text += "..."
+        elif i == last:
+            text = f"\U0001f4ac\n...{chunk_html}\n\n{footer}"
+        else:
+            text = f"\U0001f4ac\n...{chunk_html}..."
+        msg_id = await _send_message(client, config, text, reply_markup=reply_markup if i == last else None)
     return msg_id
 
 

--- a/src/webapp/server.py
+++ b/src/webapp/server.py
@@ -205,8 +205,9 @@ def create_app(config: Config) -> FastAPI:
                 yield sse("error", "Не удалось сгенерировать объяснение.")
                 return
 
-            if full_text.strip():
-                await save_explanation(reddit_id, full_text.strip())
+            text = full_text.strip()
+            if text and text[-1] in ".!?*_»\"'）)":
+                await save_explanation(reddit_id, text)
             yield sse("done", "")
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")


### PR DESCRIPTION
## Summary
- **Text split**: continuation messages now show `☝\n...` prefix and first message ends with `...`, matching the media post overflow format
- **AI explanation cache**: only cache explanations ending with sentence-ending punctuation to prevent truncated responses being saved permanently