### PR TITLE
Fall back to system ffmpeg to fix no-audio videos on Railway

### DIFF
--- a/src/scraper/media.py
+++ b/src/scraper/media.py
@@ -87,7 +87,10 @@ def _get_ffmpeg() -> str | None:
 
         return imageio_ffmpeg.get_ffmpeg_exe()
     except Exception:
-        return None
+        pass
+    import shutil
+
+    return shutil.which("ffmpeg")
 
 
 def _ffmpeg_dir_for_ytdlp() -> str | None:


### PR DESCRIPTION
## Summary
`imageio-ffmpeg` is not installed on Railway, so `_get_ffmpeg()` returned `None`, causing yt-dlp HLS download to be skipped entirely — videos were downloaded without audio via direct HTTP fallback.

Fix: fall back to `shutil.which("ffmpeg")` to find the system ffmpeg installed via `apt-get` in the Dockerfile.