### PR TITLE
Add debug logging to poller

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import logging
+import os
 import random
 import signal
 import time
@@ -32,7 +33,7 @@ from src.scraper.reddit import fetch_fresh_hls_url, fetch_top_comments, fetch_to
 from src.webapp.server import start_webapp_task
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.DEBUG if os.getenv("DEBUG_LOGGING") else logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 logger = logging.getLogger(__name__)

--- a/src/publisher/poller.py
+++ b/src/publisher/poller.py
@@ -65,6 +65,14 @@ class UpdatePoller:
         return response.json().get("result", [])
 
     def _handle_message(self, msg: dict) -> None:
+        chat_title = msg.get("chat", {}).get("title", "?")
+        logger.debug(
+            "Message in '%s': is_auto_forward=%s forward_from_message_id=%s forward_origin=%s",
+            chat_title,
+            msg.get("is_automatic_forward"),
+            msg.get("forward_from_message_id"),
+            msg.get("forward_origin", {}).get("type"),
+        )
         if not msg.get("is_automatic_forward"):
             return
         # Bot API 7.0+ moved forward fields into forward_origin.


### PR DESCRIPTION
Temporary debug: log all received messages in poller to diagnose why auto-forwarded messages are not being matched