### PR TITLE
Add 429 retry for comments and HLS refresh

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -138,7 +138,10 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
             await mark_as_published(post["reddit_id"], 0)
             return False
     elif post["post_type"] == "video" and post.get("video_url"):
-        hls_url = await fetch_fresh_hls_url(config, post["reddit_id"]) or post.get("hls_url")
+        fresh_hls = await fetch_fresh_hls_url(config, post["reddit_id"])
+        hls_url = fresh_hls or post.get("hls_url")
+        if not hls_url:
+            logger.warning("No HLS URL for %s — video will have no audio", post["reddit_id"])
         media_path = await download_video_direct(post["video_url"], hls_url=hls_url)
         if media_path:
             media_path = await asyncio.get_event_loop().run_in_executor(None, compress_video, media_path)

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -151,10 +151,10 @@ async def fetch_top_comments(config: Config, post: dict, limit: int = 5) -> list
         async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
             for attempt in range(3):
                 response = await client.get(url, params=params, headers=headers)
-                if response.status_code == 403 and attempt < 2:
-                    delay = (attempt + 1) * 5
-                    logger.info("Reddit 403 for comments %s, retrying in %ds", reddit_id, delay)
-                    await asyncio.sleep(delay)
+                if response.status_code in (403, 429) and attempt < 2:
+                    retry_after = int(response.headers.get("Retry-After", (attempt + 1) * 10))
+                    logger.info("Reddit %d for comments %s, retrying in %ds", response.status_code, reddit_id, retry_after)
+                    await asyncio.sleep(retry_after)
                     continue
                 response.raise_for_status()
                 break
@@ -205,8 +205,15 @@ async def fetch_fresh_hls_url(config: Config, reddit_id: str) -> str | None:
 
     try:
         async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
-            response = await client.get(url, params={"raw_json": 1, "limit": 1}, headers=headers)
-            response.raise_for_status()
+            for attempt in range(2):
+                response = await client.get(url, params={"raw_json": 1, "limit": 1}, headers=headers)
+                if response.status_code == 429 and attempt == 0:
+                    retry_after = int(response.headers.get("Retry-After", 10))
+                    logger.info("Reddit 429 refreshing HLS for %s, retrying in %ds", reddit_id, retry_after)
+                    await asyncio.sleep(retry_after)
+                    continue
+                response.raise_for_status()
+                break
         data = response.json()
         post_data = data[0]["data"]["children"][0]["data"]
         hls_url = (
@@ -215,7 +222,9 @@ async def fetch_fresh_hls_url(config: Config, reddit_id: str) -> str | None:
         )
         if hls_url:
             logger.info("Refreshed HLS URL for %s", reddit_id)
+        else:
+            logger.warning("No HLS URL found for %s — video will have no audio", reddit_id)
         return hls_url
     except Exception:
-        logger.debug("Could not refresh HLS URL for %s", reddit_id, exc_info=True)
+        logger.warning("Could not refresh HLS URL for %s, falling back to stored", reddit_id, exc_info=True)
         return None


### PR DESCRIPTION
## Summary
- `fetch_top_comments`: retry on 429 with Retry-After backoff (was only retrying 403)
- `fetch_fresh_hls_url`: retry once on 429; warn in log when no HLS URL found
- `main.py`: log warning when video is published without audio (no HLS URL)