### PR TITLE
Replace image text section with translated image overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
+      - run: uv sync --extra dev
       - run: uv run ruff check .
       - run: uv run ruff format --check .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=7.0",
     "respx>=0.21",
+    "imageio-ffmpeg>=0.5",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/db.py
+++ b/src/db.py
@@ -108,7 +108,10 @@ async def insert_post(post: dict) -> None:
 
 
 async def get_unpublished_posts(limit: int | None = None) -> list[dict]:
-    query = "SELECT * FROM posts WHERE published_to_tg = FALSE AND created_utc > NOW() - INTERVAL '24 hours' ORDER BY score DESC"
+    query = (
+        "SELECT * FROM posts WHERE published_to_tg = FALSE"
+        " AND created_utc > NOW() - INTERVAL '24 hours' ORDER BY score DESC"
+    )
     if limit:
         query += f" LIMIT {limit}"
     async with _pool.acquire() as conn:

--- a/src/db.py
+++ b/src/db.py
@@ -52,6 +52,8 @@ async def init_db(database_url: str) -> None:
         """)
         with contextlib.suppress(Exception):
             await conn.execute("ALTER TABLE posts ADD COLUMN IF NOT EXISTS ai_explanation TEXT")
+        with contextlib.suppress(Exception):
+            await conn.execute("ALTER TABLE posts ADD COLUMN IF NOT EXISTS translated_image BYTEA")
         await conn.execute("""
             CREATE TABLE IF NOT EXISTS settings (
                 key   TEXT PRIMARY KEY,
@@ -181,6 +183,21 @@ async def save_explanation(reddit_id: str, explanation: str) -> None:
         await conn.execute(
             "UPDATE posts SET ai_explanation = $1 WHERE reddit_id = $2",
             explanation,
+            reddit_id,
+        )
+
+
+async def get_translated_image(reddit_id: str) -> bytes | None:
+    async with _pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT translated_image FROM posts WHERE reddit_id = $1", reddit_id)
+        return bytes(row["translated_image"]) if row and row["translated_image"] else None
+
+
+async def save_translated_image(reddit_id: str, data: bytes) -> None:
+    async with _pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE posts SET translated_image = $1 WHERE reddit_id = $2",
+            data,
             reddit_id,
         )
 

--- a/src/explainer/gemini.py
+++ b/src/explainer/gemini.py
@@ -16,6 +16,7 @@ _SYSTEM_PROMPT_DEFAULT = (Path(__file__).parent / "system_prompt.txt").read_text
 async def _get_system_prompt() -> str:
     try:
         from src.db import get_setting
+
         prompt = await get_setting("system_prompt")
         return prompt if prompt else _SYSTEM_PROMPT_DEFAULT
     except Exception:
@@ -51,7 +52,10 @@ def _build_parts(post: dict, comments: list[dict] | None = None, skip_image_text
         lines.append(f"Текст: {post['selftext'][:2000]}")
     lines.append(f"Оценка: {post['score']} upvotes, {post['num_comments']} комментариев")
     if skip_image_text:
-        lines.append("\nВАЖНО: Раздел 4 (Текст с картинки) не включай — картинка с переведённым текстом уже показана пользователю отдельно.")
+        lines.append(
+            "\nВАЖНО: Раздел 4 (Текст с картинки) не включай —"
+            " картинка с переведённым текстом уже показана пользователю отдельно."
+        )
     if comments:
         lines.append("")
         lines.append("Топ комментарии (используй как контекст для понимания, не переводи):")
@@ -75,7 +79,9 @@ def _build_parts(post: dict, comments: list[dict] | None = None, skip_image_text
     return [*image_parts, text_part]
 
 
-def _build_payload(post: dict, system_prompt: str, comments: list[dict] | None = None, skip_image_text: bool = False) -> dict:
+def _build_payload(
+    post: dict, system_prompt: str, comments: list[dict] | None = None, skip_image_text: bool = False
+) -> dict:
     return {
         "system_instruction": {"parts": [{"text": system_prompt}]},
         "contents": [{"role": "user", "parts": _build_parts(post, comments, skip_image_text=skip_image_text)}],
@@ -128,7 +134,9 @@ async def stream_explanation(config: Config, post: dict, skip_image_text: bool =
     )
     async with (
         httpx.AsyncClient(timeout=60) as client,
-        client.stream("POST", url, json=_build_payload(post, system_prompt, comments, skip_image_text=skip_image_text)) as response,
+        client.stream(
+            "POST", url, json=_build_payload(post, system_prompt, comments, skip_image_text=skip_image_text)
+        ) as response,
     ):
         if response.status_code != 200:
             body = await response.aread()

--- a/src/explainer/gemini.py
+++ b/src/explainer/gemini.py
@@ -41,7 +41,7 @@ def _fetch_image(url: str) -> dict | None:
         return None
 
 
-def _build_parts(post: dict, comments: list[dict] | None = None) -> list[dict]:
+def _build_parts(post: dict, comments: list[dict] | None = None, skip_image_text: bool = False) -> list[dict]:
     lines = [
         f"Subreddit: r/{post['subreddit']}",
         f"Заголовок: {post['title']}",
@@ -50,6 +50,8 @@ def _build_parts(post: dict, comments: list[dict] | None = None) -> list[dict]:
     if post.get("selftext"):
         lines.append(f"Текст: {post['selftext'][:2000]}")
     lines.append(f"Оценка: {post['score']} upvotes, {post['num_comments']} комментариев")
+    if skip_image_text:
+        lines.append("\nВАЖНО: Раздел 4 (Текст с картинки) не включай — картинка с переведённым текстом уже показана пользователю отдельно.")
     if comments:
         lines.append("")
         lines.append("Топ комментарии (используй как контекст для понимания, не переводи):")
@@ -73,10 +75,10 @@ def _build_parts(post: dict, comments: list[dict] | None = None) -> list[dict]:
     return [*image_parts, text_part]
 
 
-def _build_payload(post: dict, system_prompt: str, comments: list[dict] | None = None) -> dict:
+def _build_payload(post: dict, system_prompt: str, comments: list[dict] | None = None, skip_image_text: bool = False) -> dict:
     return {
         "system_instruction": {"parts": [{"text": system_prompt}]},
-        "contents": [{"role": "user", "parts": _build_parts(post, comments)}],
+        "contents": [{"role": "user", "parts": _build_parts(post, comments, skip_image_text=skip_image_text)}],
         "generationConfig": {
             "maxOutputTokens": 2048,
             "temperature": 0.4,
@@ -116,7 +118,7 @@ async def generate_explanation(config: Config, post: dict) -> str:
         return "Не удалось сгенерировать объяснение."
 
 
-async def stream_explanation(config: Config, post: dict) -> AsyncIterator[str]:
+async def stream_explanation(config: Config, post: dict, skip_image_text: bool = False) -> AsyncIterator[str]:
     """Stream explanation chunks from Gemini SSE endpoint."""
     comments = await _safe_fetch_comments(config, post)
     system_prompt = await _get_system_prompt()
@@ -126,7 +128,7 @@ async def stream_explanation(config: Config, post: dict) -> AsyncIterator[str]:
     )
     async with (
         httpx.AsyncClient(timeout=60) as client,
-        client.stream("POST", url, json=_build_payload(post, system_prompt, comments)) as response,
+        client.stream("POST", url, json=_build_payload(post, system_prompt, comments, skip_image_text=skip_image_text)) as response,
     ):
         if response.status_code != 200:
             body = await response.aread()

--- a/src/explainer/image_processor.py
+++ b/src/explainer/image_processor.py
@@ -66,11 +66,7 @@ async def detect_image_text(image_url: str, config: Config) -> list[dict]:
 
 def _valid_region(r: dict) -> bool:
     return (
-        isinstance(r, dict)
-        and "translation" in r
-        and "box" in r
-        and isinstance(r["box"], list)
-        and len(r["box"]) == 4
+        isinstance(r, dict) and "translation" in r and "box" in r and isinstance(r["box"], list) and len(r["box"]) == 4
     )
 
 

--- a/src/explainer/image_processor.py
+++ b/src/explainer/image_processor.py
@@ -1,0 +1,149 @@
+import io
+import json
+import logging
+import statistics
+
+import httpx
+from PIL import Image, ImageDraw, ImageFont
+
+from src.config import Config
+
+logger = logging.getLogger(__name__)
+
+_DETECT_PROMPT = (
+    "Detect all text visible in this image and translate each piece to Russian. "
+    "Return ONLY valid JSON with no markdown, no explanation, no code block:\n"
+    '[{"text": "original text", "translation": "русский перевод", '
+    '"box": [y_min, x_min, y_max, x_max]}]\n'
+    "box values are integers normalized to 0–1000 "
+    "(y_min/y_max = top/bottom distance from top, x_min/x_max = left/right distance from left). "
+    "If there is no text in the image return exactly: []"
+)
+
+
+async def detect_image_text(image_url: str, config: Config) -> list[dict]:
+    from src.explainer.gemini import _fetch_image
+
+    image_part = _fetch_image(image_url)
+    if not image_part:
+        return []
+
+    payload = {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [image_part, {"text": _DETECT_PROMPT}],
+            }
+        ],
+        "generationConfig": {
+            "maxOutputTokens": 2048,
+            "temperature": 0.1,
+            "thinkingConfig": {"thinkingBudget": 0},
+        },
+    }
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"gemini-3.1-flash-lite:generateContent?key={config.gemini_api_key}"
+    )
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(url, json=payload)
+            resp.raise_for_status()
+        raw = resp.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
+        # Strip markdown code block if model wraps response
+        if raw.startswith("```"):
+            raw = raw.split("```")[1]
+            if raw.startswith("json"):
+                raw = raw[4:]
+        regions = json.loads(raw)
+        if not isinstance(regions, list):
+            return []
+        return [r for r in regions if _valid_region(r)]
+    except Exception as e:
+        logger.debug("Image text detection failed: %s", e)
+        return []
+
+
+def _valid_region(r: dict) -> bool:
+    return (
+        isinstance(r, dict)
+        and "translation" in r
+        and "box" in r
+        and isinstance(r["box"], list)
+        and len(r["box"]) == 4
+    )
+
+
+def _median_color(pixels: list[tuple]) -> tuple[int, int, int]:
+    if not pixels:
+        return (255, 255, 255)
+    r = statistics.median(p[0] for p in pixels)
+    g = statistics.median(p[1] for p in pixels)
+    b = statistics.median(p[2] for p in pixels)
+    return (int(r), int(g), int(b))
+
+
+def _contrasting(color: tuple[int, int, int]) -> tuple[int, int, int]:
+    luminance = 0.299 * color[0] + 0.587 * color[1] + 0.114 * color[2]
+    return (0, 0, 0) if luminance > 128 else (255, 255, 255)
+
+
+def _fit_text(draw: ImageDraw.ImageDraw, text: str, box_w: int, box_h: int) -> tuple[ImageFont.ImageFont, int, int]:
+    for size in range(max(8, int(box_h * 0.4)), 7, -1):
+        font = ImageFont.load_default(size=size)
+        bbox = draw.textbbox((0, 0), text, font=font)
+        tw = bbox[2] - bbox[0]
+        th = bbox[3] - bbox[1]
+        if tw <= box_w and th <= box_h:
+            return font, tw, th
+    font = ImageFont.load_default(size=8)
+    bbox = draw.textbbox((0, 0), text, font=font)
+    return font, bbox[2] - bbox[0], bbox[3] - bbox[1]
+
+
+def overlay_translations(image_bytes: bytes, regions: list[dict]) -> bytes:
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    w, h = img.size
+    draw = ImageDraw.Draw(img)
+
+    for region in regions:
+        box = region["box"]
+        text = region["translation"]
+
+        y_min = max(0, int(box[0] * h / 1000))
+        x_min = max(0, int(box[1] * w / 1000))
+        y_max = min(h, int(box[2] * h / 1000))
+        x_max = min(w, int(box[3] * w / 1000))
+
+        if x_max <= x_min or y_max <= y_min:
+            continue
+
+        # Sample border pixels to estimate background
+        border: list[tuple] = []
+        for x in range(x_min, x_max):
+            if y_min < h:
+                border.append(img.getpixel((x, y_min)))
+            if y_max - 1 < h:
+                border.append(img.getpixel((x, y_max - 1)))
+        for y in range(y_min, y_max):
+            if x_min < w:
+                border.append(img.getpixel((x_min, y)))
+            if x_max - 1 < w:
+                border.append(img.getpixel((x_max - 1, y)))
+
+        bg = _median_color(border)
+        fg = _contrasting(bg)
+
+        draw.rectangle([x_min, y_min, x_max, y_max], fill=bg)
+
+        box_w = x_max - x_min - 4
+        box_h = y_max - y_min - 4
+        font, tw, th = _fit_text(draw, text, box_w, box_h)
+
+        tx = x_min + (box_w - tw) // 2 + 2
+        ty = y_min + (box_h - th) // 2 + 2
+        draw.text((tx, ty), text, fill=fg, font=font)
+
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -153,7 +153,12 @@ async def fetch_top_comments(config: Config, post: dict, limit: int = 5) -> list
                 response = await client.get(url, params=params, headers=headers)
                 if response.status_code in (403, 429) and attempt < 2:
                     retry_after = int(response.headers.get("Retry-After", (attempt + 1) * 10))
-                    logger.info("Reddit %d for comments %s, retrying in %ds", response.status_code, reddit_id, retry_after)
+                    logger.info(
+                        "Reddit %d for comments %s, retrying in %ds",
+                        response.status_code,
+                        reddit_id,
+                        retry_after,
+                    )
                     await asyncio.sleep(retry_after)
                     continue
                 response.raise_for_status()
@@ -216,10 +221,9 @@ async def fetch_fresh_hls_url(config: Config, reddit_id: str) -> str | None:
                 break
         data = response.json()
         post_data = data[0]["data"]["children"][0]["data"]
-        hls_url = (
-            (post_data.get("media") or {}).get("reddit_video", {}).get("hls_url")
-            or (post_data.get("secure_media") or {}).get("reddit_video", {}).get("hls_url")
-        )
+        hls_url = (post_data.get("media") or {}).get("reddit_video", {}).get("hls_url") or (
+            post_data.get("secure_media") or {}
+        ).get("reddit_video", {}).get("hls_url")
         if hls_url:
             logger.info("Refreshed HLS URL for %s", reddit_id)
         else:

--- a/src/webapp/server.py
+++ b/src/webapp/server.py
@@ -18,8 +18,7 @@ from src.db import (
     save_setting,
     save_translated_image,
 )
-from src.explainer.gemini import _SYSTEM_PROMPT_DEFAULT
-from src.explainer.gemini import stream_explanation
+from src.explainer.gemini import _SYSTEM_PROMPT_DEFAULT, stream_explanation
 from src.explainer.image_processor import detect_image_text, overlay_translations
 
 logger = logging.getLogger(__name__)
@@ -242,9 +241,7 @@ def create_app(config: Config) -> FastAPI:
             return HTMLResponse("<h3>Unauthorized</h3>", status_code=401)
         await save_setting("system_prompt", prompt.strip())
         logger.info("System prompt updated (%d chars)", len(prompt))
-        return HTMLResponse(
-            f'<meta http-equiv="refresh" content="0;url=/admin/prompt?secret={secret}">'
-        )
+        return HTMLResponse(f'<meta http-equiv="refresh" content="0;url=/admin/prompt?secret={secret}">')
 
     @app.get("/api/image/{reddit_id}")
     async def image_endpoint(reddit_id: str):
@@ -287,7 +284,8 @@ def create_app(config: Config) -> FastAPI:
                         if image_url:
                             regions = await detect_image_text(image_url, config)
                             if regions:
-                                raw_resp = httpx.get(image_url, timeout=15, follow_redirects=True)
+                                async with httpx.AsyncClient(timeout=15) as img_client:
+                                    raw_resp = await img_client.get(image_url, follow_redirects=True)
                                 raw_resp.raise_for_status()
                                 image_data = overlay_translations(raw_resp.content, regions)
                                 await save_translated_image(reddit_id, image_data)

--- a/src/webapp/server.py
+++ b/src/webapp/server.py
@@ -2,14 +2,25 @@ import asyncio
 import json
 import logging
 
+import httpx
 import uvicorn
 from fastapi import FastAPI, Form
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 
 from src.config import Config
-from src.db import get_explanation, get_post, get_setting, mark_as_unpublished, save_explanation, save_setting
+from src.db import (
+    get_explanation,
+    get_post,
+    get_setting,
+    get_translated_image,
+    mark_as_unpublished,
+    save_explanation,
+    save_setting,
+    save_translated_image,
+)
 from src.explainer.gemini import _SYSTEM_PROMPT_DEFAULT
 from src.explainer.gemini import stream_explanation
+from src.explainer.image_processor import detect_image_text, overlay_translations
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +79,7 @@ _MINI_APP_HTML = """<!DOCTYPE html>
     50% { opacity: 0; }
   }
   .error { color: var(--tg-theme-destructive-text-color, #e74c3c); padding: 16px 0; }
+  .post-image { width: 100%; border-radius: 8px; margin-bottom: 12px; display: block; }
 </style>
 </head>
 <body>
@@ -129,6 +141,14 @@ _MINI_APP_HTML = """<!DOCTYPE html>
     let started = false;
     let buffer = '';
 
+    evt.addEventListener('image', (e) => {
+      const url = JSON.parse(e.data);
+      const img = document.createElement('img');
+      img.src = url;
+      img.className = 'post-image';
+      document.querySelector('.container').prepend(img);
+      loading.style.display = 'none';
+    });
     evt.addEventListener('chunk', (e) => {
       if (!started) {
         loading.style.display = 'none';
@@ -226,20 +246,30 @@ def create_app(config: Config) -> FastAPI:
             f'<meta http-equiv="refresh" content="0;url=/admin/prompt?secret={secret}">'
         )
 
+    @app.get("/api/image/{reddit_id}")
+    async def image_endpoint(reddit_id: str):
+        data = await get_translated_image(reddit_id)
+        if not data:
+            return Response(status_code=404)
+        return Response(content=data, media_type="image/jpeg")
+
     @app.get("/api/explain/stream")
     async def explain_stream(reddit_id: str):
         def sse(event: str, data: str) -> str:
             return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
 
         async def event_stream():
-            cached = await get_explanation(reddit_id)
-            if cached and len(cached) >= 50:
-                yield sse("chunk", cached)
-                yield sse("done", "")
-                return
-
             if not config.gemini_api_key:
                 yield sse("error", "AI не настроен.")
+                return
+
+            cached = await get_explanation(reddit_id)
+            if cached and len(cached) >= 50:
+                image_data = await get_translated_image(reddit_id)
+                if image_data:
+                    yield sse("image", f"/api/image/{reddit_id}")
+                yield sse("chunk", cached)
+                yield sse("done", "")
                 return
 
             post = await get_post(reddit_id)
@@ -247,9 +277,29 @@ def create_app(config: Config) -> FastAPI:
                 yield sse("error", "Пост не найден.")
                 return
 
+            # Try image text translation for single-image posts
+            skip_image_text = False
+            if post.get("post_type") == "image":
+                try:
+                    image_data = await get_translated_image(reddit_id)
+                    if not image_data:
+                        image_url = post.get("content_url") or post.get("preview_url")
+                        if image_url:
+                            regions = await detect_image_text(image_url, config)
+                            if regions:
+                                raw_resp = httpx.get(image_url, timeout=15, follow_redirects=True)
+                                raw_resp.raise_for_status()
+                                image_data = overlay_translations(raw_resp.content, regions)
+                                await save_translated_image(reddit_id, image_data)
+                    if image_data:
+                        yield sse("image", f"/api/image/{reddit_id}")
+                        skip_image_text = True
+                except Exception as e:
+                    logger.debug("Image translation pipeline failed for %s: %s", reddit_id, e)
+
             full_text = ""
             try:
-                async for chunk in stream_explanation(config, post):
+                async for chunk in stream_explanation(config, post, skip_image_text=skip_image_text):
                     full_text += chunk
                     yield sse("chunk", chunk)
             except Exception as e:

--- a/tests/test_db_extended.py
+++ b/tests/test_db_extended.py
@@ -1,5 +1,5 @@
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import src.db as db_module
@@ -35,6 +35,7 @@ def _make_pool(fetchrow_return=None, fetch_return=None, execute_return="UPDATE 1
 
 
 # --- get_unpublished_posts ---
+
 
 async def test_get_unpublished_posts_empty():
     pool, conn = _make_pool(fetch_return=[])
@@ -88,6 +89,7 @@ async def test_get_unpublished_posts_null_media_urls_stays_none():
 
 # --- mark_as_unpublished ---
 
+
 async def test_mark_as_unpublished_clears_fields():
     pool, conn = _make_pool()
     with patch.object(db_module, "_pool", pool):
@@ -100,6 +102,7 @@ async def test_mark_as_unpublished_clears_fields():
 
 
 # --- get_post ---
+
 
 async def test_get_post_found():
     pool, conn = _make_pool(fetchrow_return={"reddit_id": "t3_abc", "media_urls": None})
@@ -123,6 +126,7 @@ async def test_get_post_deserializes_media_urls():
 
 
 # --- get_explanation / save_explanation ---
+
 
 async def test_get_explanation_returns_text():
     pool, conn = _make_pool(fetchrow_return={"ai_explanation": "Some explanation."})
@@ -148,6 +152,7 @@ async def test_save_explanation_passes_correct_args():
 
 
 # --- log_scrape ---
+
 
 async def test_log_scrape_inserts_row():
     pool, conn = _make_pool()

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,12 +1,11 @@
-import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from src.scraper.media import _get_duration, _get_ffmpeg, cleanup
 
-
 # --- _get_ffmpeg ---
+
 
 def test_get_ffmpeg_uses_imageio_when_available():
     with patch("imageio_ffmpeg.get_ffmpeg_exe", return_value="/fake/ffmpeg"):
@@ -15,20 +14,25 @@ def test_get_ffmpeg_uses_imageio_when_available():
 
 
 def test_get_ffmpeg_falls_back_to_system():
-    with patch("imageio_ffmpeg.get_ffmpeg_exe", side_effect=Exception("not found")):
-        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
-            result = _get_ffmpeg()
+    with (
+        patch("imageio_ffmpeg.get_ffmpeg_exe", side_effect=Exception("not found")),
+        patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+    ):
+        result = _get_ffmpeg()
     assert result == "/usr/bin/ffmpeg"
 
 
 def test_get_ffmpeg_returns_none_when_neither_available():
-    with patch("imageio_ffmpeg.get_ffmpeg_exe", side_effect=Exception("not found")):
-        with patch("shutil.which", return_value=None):
-            result = _get_ffmpeg()
+    with (
+        patch("imageio_ffmpeg.get_ffmpeg_exe", side_effect=Exception("not found")),
+        patch("shutil.which", return_value=None),
+    ):
+        result = _get_ffmpeg()
     assert result is None
 
 
 # --- _get_duration ---
+
 
 def _fake_run(cmd, capture_output, text):
     result = MagicMock()
@@ -52,6 +56,7 @@ def test_get_duration_returns_none_on_no_match():
 
 # --- cleanup ---
 
+
 def test_cleanup_deletes_file():
     with tempfile.NamedTemporaryFile(delete=False) as f:
         path = Path(f.name)
@@ -67,46 +72,53 @@ def test_cleanup_silently_ignores_missing_file():
 
 # --- download_video_direct (unit) ---
 
+
 async def test_download_video_direct_skips_hls_when_no_ffmpeg():
-    with patch("src.scraper.media._ffmpeg_dir_for_ytdlp", return_value=None):
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_resp = MagicMock()
-            mock_resp.status_code = 200
-            mock_resp.content = b"fake_video_bytes"
-            mock_resp.raise_for_status = MagicMock()
-            mock_client.__aenter__ = lambda s: s
-            mock_client.__aexit__ = MagicMock(return_value=False)
+    with (
+        patch("src.scraper.media._ffmpeg_dir_for_ytdlp", return_value=None),
+        patch("httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"fake_video_bytes"
+        mock_resp.raise_for_status = MagicMock()
+        mock_client.__aenter__ = lambda s: s
+        mock_client.__aexit__ = MagicMock(return_value=False)
 
-            async def fake_get(url, **kwargs):
-                return mock_resp
+        async def fake_get(url, **kwargs):
+            return mock_resp
 
-            mock_client.get = fake_get
-            mock_client_cls.return_value = mock_client
+        mock_client.get = fake_get
+        mock_client_cls.return_value = mock_client
 
-            from src.scraper.media import download_video_direct
-            result = await download_video_direct(
-                "https://v.redd.it/abc/DASH_720.mp4",
-                hls_url="https://v.redd.it/abc/HLSPlaylist.m3u8?a=token",
-            )
+        from src.scraper.media import download_video_direct
+
+        result = await download_video_direct(
+            "https://v.redd.it/abc/DASH_720.mp4",
+            hls_url="https://v.redd.it/abc/HLSPlaylist.m3u8?a=token",
+        )
     # With no ffmpeg, falls back to direct download
     if result:
         cleanup(result)
 
 
 async def test_download_video_direct_returns_none_on_failure():
-    with patch("src.scraper.media._ffmpeg_dir_for_ytdlp", return_value=None):
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = MagicMock()
+    with (
+        patch("src.scraper.media._ffmpeg_dir_for_ytdlp", return_value=None),
+        patch("httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = MagicMock()
 
-            async def fake_get(url, **kwargs):
-                raise Exception("connection error")
+        async def fake_get(url, **kwargs):
+            raise Exception("connection error")
 
-            mock_client.get = fake_get
-            mock_client.__aenter__ = lambda s: s
-            mock_client.__aexit__ = MagicMock(return_value=False)
-            mock_client_cls.return_value = mock_client
+        mock_client.get = fake_get
+        mock_client.__aenter__ = lambda s: s
+        mock_client.__aexit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client
 
-            from src.scraper.media import download_video_direct
-            result = await download_video_direct("https://v.redd.it/abc/DASH_720.mp4")
+        from src.scraper.media import download_video_direct
+
+        result = await download_video_direct("https://v.redd.it/abc/DASH_720.mp4")
     assert result is None

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1,5 +1,4 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import respx
 from httpx import Response
@@ -19,6 +18,7 @@ def _make_poller():
 
 
 # --- register_post / wait_for_discussion_id ---
+
 
 async def test_register_creates_future():
     poller = _make_poller()
@@ -55,6 +55,7 @@ async def test_wait_returns_none_when_not_registered():
 
 
 # --- _handle_message ---
+
 
 def test_handle_message_auto_forward_resolves_future():
     poller = _make_poller()
@@ -125,6 +126,7 @@ def test_handle_message_no_match_leaves_future_pending():
 
 # --- _poll_once ---
 
+
 @respx.mock
 async def test_poll_once_advances_offset():
     updates_response = {
@@ -138,6 +140,7 @@ async def test_poll_once_advances_offset():
     )
     poller = _make_poller()
     import httpx
+
     async with httpx.AsyncClient(timeout=None) as client:
         updates = await poller._poll_once(client)
     assert len(updates) == 2
@@ -150,6 +153,7 @@ async def test_poll_once_returns_empty_on_non_200():
     )
     poller = _make_poller()
     import httpx
+
     async with httpx.AsyncClient(timeout=None) as client:
         updates = await poller._poll_once(client)
     assert updates == []

--- a/tests/test_publisher_extended.py
+++ b/tests/test_publisher_extended.py
@@ -43,6 +43,7 @@ BASE_POST = {
 
 # --- _md_to_telegram_html ---
 
+
 def test_md_bold_double_star():
     assert "<b>hello</b>" in _md_to_telegram_html("**hello**")
 
@@ -91,6 +92,7 @@ def test_md_plain_text_unchanged():
 
 # --- _build_footer ---
 
+
 def test_footer_contains_subreddit_link():
     footer = _build_footer(BASE_POST, CONFIG)
     assert "r/funny" in footer
@@ -126,6 +128,7 @@ def test_footer_link_post_skips_reddit_domain():
 
 # --- _chunk_text_evenly ---
 
+
 def test_chunk_evenly_single_chunk():
     chunks = _chunk_text_evenly("short", "footer")
     assert len(chunks) == 1
@@ -152,6 +155,7 @@ def test_chunk_evenly_middle_chunks_have_prefix():
 
 # --- _publish_text_messages ---
 
+
 @respx.mock
 async def test_publish_text_single_message():
     respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(
@@ -159,6 +163,7 @@ async def test_publish_text_single_message():
     )
     post = {**BASE_POST, "selftext": "Short text."}
     import httpx
+
     async with httpx.AsyncClient() as client:
         msg_id = await _publish_text_messages(client, CONFIG, post)
     assert msg_id == 1
@@ -176,6 +181,7 @@ async def test_publish_text_split_adds_continuation_marker():
     # 900 words × 5 chars = 4500 chars → exceeds MAX_MESSAGE_LEN (4096) → forces split
     post = {**BASE_POST, "selftext": "word " * 900}
     import httpx
+
     async with httpx.AsyncClient() as client:
         await _publish_text_messages(client, CONFIG, post)
     assert len(call_bodies) >= 2
@@ -193,6 +199,7 @@ async def test_publish_text_first_message_ends_with_ellipsis_when_split():
     respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(side_effect=capture)
     post = {**BASE_POST, "selftext": "word " * 900}
     import httpx
+
     async with httpx.AsyncClient() as client:
         await _publish_text_messages(client, CONFIG, post)
     assert len(call_bodies) >= 2

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
 
 import respx
 from httpx import Response
@@ -34,6 +33,7 @@ SAMPLE_POST = {
 
 # --- fetch_top_posts ---
 
+
 @respx.mock
 async def test_fetch_top_posts_skips_removed():
     fixture = json.loads(json.dumps(FIXTURE))
@@ -54,9 +54,7 @@ async def test_fetch_top_posts_skips_deleted_author():
 
 @respx.mock
 async def test_fetch_top_posts_uses_proxy_url_and_secret():
-    respx.get("https://proxy.example.com/.json").mock(
-        return_value=Response(200, json=FIXTURE)
-    )
+    respx.get("https://proxy.example.com/.json").mock(return_value=Response(200, json=FIXTURE))
     posts = await fetch_top_posts(CONFIG_WITH_PROXY)
     assert len(posts) == 6
     request = respx.calls.last.request
@@ -125,9 +123,7 @@ async def test_fetch_top_comments_filters_stickied():
 
 @respx.mock
 async def test_fetch_top_comments_returns_empty_on_error():
-    respx.get("https://www.reddit.com/r/funny/comments/abc123.json").mock(
-        return_value=Response(500)
-    )
+    respx.get("https://www.reddit.com/r/funny/comments/abc123.json").mock(return_value=Response(500))
     comments = await fetch_top_comments(CONFIG, SAMPLE_POST)
     assert comments == []
 
@@ -156,9 +152,7 @@ async def test_fetch_top_comments_sorted_by_score():
             }
         },
     ]
-    respx.get("https://www.reddit.com/r/funny/comments/abc123.json").mock(
-        return_value=Response(200, json=fixture)
-    )
+    respx.get("https://www.reddit.com/r/funny/comments/abc123.json").mock(return_value=Response(200, json=fixture))
     comments = await fetch_top_comments(CONFIG, SAMPLE_POST)
     assert comments[0]["author"] == "high"
 
@@ -169,15 +163,7 @@ HLS_POST_FIXTURE = [
     {
         "data": {
             "children": [
-                {
-                    "data": {
-                        "media": {
-                            "reddit_video": {
-                                "hls_url": "https://v.redd.it/abc/HLSPlaylist.m3u8?a=newtoken"
-                            }
-                        }
-                    }
-                }
+                {"data": {"media": {"reddit_video": {"hls_url": "https://v.redd.it/abc/HLSPlaylist.m3u8?a=newtoken"}}}}
             ]
         }
     }
@@ -186,18 +172,14 @@ HLS_POST_FIXTURE = [
 
 @respx.mock
 async def test_fetch_fresh_hls_url_returns_url():
-    respx.get("https://www.reddit.com/comments/abc123.json").mock(
-        return_value=Response(200, json=HLS_POST_FIXTURE)
-    )
+    respx.get("https://www.reddit.com/comments/abc123.json").mock(return_value=Response(200, json=HLS_POST_FIXTURE))
     result = await fetch_fresh_hls_url(CONFIG, "t3_abc123")
     assert result == "https://v.redd.it/abc/HLSPlaylist.m3u8?a=newtoken"
 
 
 @respx.mock
 async def test_fetch_fresh_hls_url_uses_proxy():
-    respx.get("https://proxy.example.com/comments/abc123.json").mock(
-        return_value=Response(200, json=HLS_POST_FIXTURE)
-    )
+    respx.get("https://proxy.example.com/comments/abc123.json").mock(return_value=Response(200, json=HLS_POST_FIXTURE))
     result = await fetch_fresh_hls_url(CONFIG_WITH_PROXY, "t3_abc123")
     assert result is not None
     request = respx.calls.last.request
@@ -206,9 +188,7 @@ async def test_fetch_fresh_hls_url_uses_proxy():
 
 @respx.mock
 async def test_fetch_fresh_hls_url_returns_none_on_failure():
-    respx.get("https://www.reddit.com/comments/abc123.json").mock(
-        return_value=Response(500)
-    )
+    respx.get("https://www.reddit.com/comments/abc123.json").mock(return_value=Response(500))
     result = await fetch_fresh_hls_url(CONFIG, "t3_abc123")
     assert result is None
 
@@ -216,8 +196,6 @@ async def test_fetch_fresh_hls_url_returns_none_on_failure():
 @respx.mock
 async def test_fetch_fresh_hls_url_returns_none_when_no_video():
     fixture = [{"data": {"children": [{"data": {"media": None}}]}}]
-    respx.get("https://www.reddit.com/comments/abc123.json").mock(
-        return_value=Response(200, json=fixture)
-    )
+    respx.get("https://www.reddit.com/comments/abc123.json").mock(return_value=Response(200, json=fixture))
     result = await fetch_fresh_hls_url(CONFIG, "t3_abc123")
     assert result is None

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -69,8 +69,9 @@ async def test_explain_returns_error_when_not_cached():
 async def test_explain_stream_serves_cached_explanation():
     long_cached = "A" * 60 + "."
     with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=long_cached):
-        async with await _client() as c:
-            resp = await c.get("/api/explain/stream?reddit_id=t3_abc")
+        with patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None):
+            async with await _client() as c:
+                resp = await c.get("/api/explain/stream?reddit_id=t3_abc")
     assert resp.status_code == 200
     assert long_cached in resp.text
 
@@ -108,28 +109,32 @@ async def test_explain_stream_no_gemini_key():
 async def test_explain_stream_caches_only_complete_response():
     fake_post = {"reddit_id": "t3_abc", "title": "Test", "post_type": "image"}
 
-    async def fake_stream(config, post):
+    async def fake_stream(config, post, skip_image_text=False):
         yield "Complete answer."
 
     with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None):
         with patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post):
-            with patch("src.webapp.server.stream_explanation", side_effect=fake_stream):
-                with patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save:
-                    async with await _client() as c:
-                        await c.get("/api/explain/stream?reddit_id=t3_abc")
+            with patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None):
+                with patch("src.webapp.server.detect_image_text", new_callable=AsyncMock, return_value=[]):
+                    with patch("src.webapp.server.stream_explanation", side_effect=fake_stream):
+                        with patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save:
+                            async with await _client() as c:
+                                await c.get("/api/explain/stream?reddit_id=t3_abc")
     mock_save.assert_awaited_once()
 
 
 async def test_explain_stream_does_not_cache_truncated_response():
     fake_post = {"reddit_id": "t3_abc", "title": "Test", "post_type": "image"}
 
-    async def fake_stream(config, post):
+    async def fake_stream(config, post, skip_image_text=False):
         yield "Truncated mid-sentenc"  # no ending punctuation
 
     with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None):
         with patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post):
-            with patch("src.webapp.server.stream_explanation", side_effect=fake_stream):
-                with patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save:
-                    async with await _client() as c:
-                        await c.get("/api/explain/stream?reddit_id=t3_abc")
+            with patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None):
+                with patch("src.webapp.server.detect_image_text", new_callable=AsyncMock, return_value=[]):
+                    with patch("src.webapp.server.stream_explanation", side_effect=fake_stream):
+                        with patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save:
+                            async with await _client() as c:
+                                await c.get("/api/explain/stream?reddit_id=t3_abc")
     mock_save.assert_not_awaited()

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,6 +1,5 @@
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.config import Config
@@ -22,6 +21,7 @@ async def _client(config=CONFIG):
 
 # --- /health ---
 
+
 async def test_health_returns_ok():
     async with await _client() as c:
         resp = await c.get("/health")
@@ -30,6 +30,7 @@ async def test_health_returns_ok():
 
 
 # --- /admin/reset ---
+
 
 async def test_admin_reset_wrong_secret():
     async with await _client() as c:
@@ -47,6 +48,7 @@ async def test_admin_reset_correct_secret():
 
 
 # --- /api/explain ---
+
 
 async def test_explain_returns_cached():
     with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value="Cached text."):
@@ -66,29 +68,36 @@ async def test_explain_returns_error_when_not_cached():
 
 # --- /api/explain/stream ---
 
+
 async def test_explain_stream_serves_cached_explanation():
     long_cached = "A" * 60 + "."
-    with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=long_cached):
-        with patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None):
-            async with await _client() as c:
-                resp = await c.get("/api/explain/stream?reddit_id=t3_abc")
+    with (
+        patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=long_cached),
+        patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None),
+    ):
+        async with await _client() as c:
+            resp = await c.get("/api/explain/stream?reddit_id=t3_abc")
     assert resp.status_code == 200
     assert long_cached in resp.text
 
 
 async def test_explain_stream_ignores_short_cache():
-    with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value="short"):
-        with patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=None):
-            async with await _client() as c:
-                resp = await c.get("/api/explain/stream?reddit_id=t3_abc")
+    with (
+        patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value="short"),
+        patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=None),
+    ):
+        async with await _client() as c:
+            resp = await c.get("/api/explain/stream?reddit_id=t3_abc")
     assert "Пост не найден" in resp.text
 
 
 async def test_explain_stream_post_not_found():
-    with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None):
-        with patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=None):
-            async with await _client() as c:
-                resp = await c.get("/api/explain/stream?reddit_id=t3_missing")
+    with (
+        patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None),
+        patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=None),
+    ):
+        async with await _client() as c:
+            resp = await c.get("/api/explain/stream?reddit_id=t3_missing")
     assert "Пост не найден" in resp.text
 
 
@@ -112,14 +121,16 @@ async def test_explain_stream_caches_only_complete_response():
     async def fake_stream(config, post, skip_image_text=False):
         yield "Complete answer."
 
-    with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None):
-        with patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post):
-            with patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None):
-                with patch("src.webapp.server.detect_image_text", new_callable=AsyncMock, return_value=[]):
-                    with patch("src.webapp.server.stream_explanation", side_effect=fake_stream):
-                        with patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save:
-                            async with await _client() as c:
-                                await c.get("/api/explain/stream?reddit_id=t3_abc")
+    with (
+        patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None),
+        patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post),
+        patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None),
+        patch("src.webapp.server.detect_image_text", new_callable=AsyncMock, return_value=[]),
+        patch("src.webapp.server.stream_explanation", side_effect=fake_stream),
+        patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save,
+    ):
+        async with await _client() as c:
+            await c.get("/api/explain/stream?reddit_id=t3_abc")
     mock_save.assert_awaited_once()
 
 
@@ -129,12 +140,14 @@ async def test_explain_stream_does_not_cache_truncated_response():
     async def fake_stream(config, post, skip_image_text=False):
         yield "Truncated mid-sentenc"  # no ending punctuation
 
-    with patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None):
-        with patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post):
-            with patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None):
-                with patch("src.webapp.server.detect_image_text", new_callable=AsyncMock, return_value=[]):
-                    with patch("src.webapp.server.stream_explanation", side_effect=fake_stream):
-                        with patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save:
-                            async with await _client() as c:
-                                await c.get("/api/explain/stream?reddit_id=t3_abc")
+    with (
+        patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None),
+        patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post),
+        patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None),
+        patch("src.webapp.server.detect_image_text", new_callable=AsyncMock, return_value=[]),
+        patch("src.webapp.server.stream_explanation", side_effect=fake_stream),
+        patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save,
+    ):
+        async with await _client() as c:
+            await c.get("/api/explain/stream?reddit_id=t3_abc")
     mock_save.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -510,6 +510,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -858,6 +872,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "imageio-ffmpeg" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -871,6 +886,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "google-genai", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "imageio-ffmpeg", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },


### PR DESCRIPTION
## Summary

- Добавлен пайплайн перевода текста на картинках: Gemini определяет текстовые регионы с bounding box-ами, Pillow закрашивает оригинальный текст и рисует русский перевод поверх
- Обработанная картинка кэшируется в БД (колонка `translated_image BYTEA`) и отдаётся через новый эндпоинт `GET /api/image/{reddit_id}`
- В Telegram Web App картинка показывается перед текстовым объяснением через новое SSE-событие `image`
- Раздел 4 системного промпта («Текст с картинки») динамически подавляется, когда картинка была обработана
- При любой ошибке пайплайна (сеть, Gemini, Pillow) — graceful degradation: объяснение генерируется как раньше с текстовым разделом 4

## Test plan

- [ ] Найти пост с мемом/картинкой с текстом в БД, открыть его через Web App — картинка с русским текстом должна появиться перед объяснением
- [ ] Убедиться, что раздел «На картинке написано:» не появляется в тексте объяснения
- [ ] Проверить пост без текста на картинке — картинка не показывается, объяснение генерируется как обычно
- [ ] `pytest` — 103 теста проходят