### PR TITLE
Regenerate image-post explanations cached before overlay feature

### DIFF
--- a/src/webapp/server.py
+++ b/src/webapp/server.py
@@ -261,17 +261,15 @@ def create_app(config: Config) -> FastAPI:
                 return
 
             cached = await get_explanation(reddit_id)
-            if cached and len(cached) >= 50:
-                image_data = await get_translated_image(reddit_id)
-                if image_data:
-                    yield sse("image", f"/api/image/{reddit_id}")
-                yield sse("chunk", cached)
-                yield sse("done", "")
-                return
-
             post = await get_post(reddit_id)
             if not post:
                 yield sse("error", "Пост не найден.")
+                return
+
+            # For non-image posts: serve from cache if available
+            if cached and len(cached) >= 50 and post.get("post_type") != "image":
+                yield sse("chunk", cached)
+                yield sse("done", "")
                 return
 
             # Try image text translation for single-image posts
@@ -294,6 +292,14 @@ def create_app(config: Config) -> FastAPI:
                         skip_image_text = True
                 except Exception as e:
                     logger.debug("Image translation pipeline failed for %s: %s", reddit_id, e)
+
+            # Serve from cache only when image pipeline is consistent with cache:
+            # - no image overlay (pipeline didn't run) and cache exists → use cache
+            # - image overlay generated but cache was made before (may contain section 4) → regenerate
+            if cached and len(cached) >= 50 and not skip_image_text:
+                yield sse("chunk", cached)
+                yield sse("done", "")
+                return
 
             full_text = ""
             try:

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -71,9 +71,10 @@ async def test_explain_returns_error_when_not_cached():
 
 async def test_explain_stream_serves_cached_explanation():
     long_cached = "A" * 60 + "."
+    fake_post = {"reddit_id": "t3_abc", "title": "Test", "post_type": "text"}
     with (
         patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=long_cached),
-        patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None),
+        patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post),
     ):
         async with await _client() as c:
             resp = await c.get("/api/explain/stream?reddit_id=t3_abc")


### PR DESCRIPTION
## Summary

- Image-посты с закэшированным объяснением (созданным до деплоя оверлея) теперь регенерируются заново: пайплайн перевода картинки запускается, и новое объяснение сохраняется без раздела 4
- Не-image посты по-прежнему отдаются из кэша без лишних вызовов
- Кэш используется только если: пайплайн картинки не применялся (`skip_image_text=False`) — значит либо не image-пост, либо на картинке нет текста

## Test plan

- [ ] Открыть AI-explanation для поста с мемом — должна появиться картинка с русским текстом, раздел «На картинке написано:» исчезнуть
- [ ] Открыть повторно — из нового кэша должен грузиться быстро (объяснение без раздела 4)
- [ ] Пост без картинки — объяснение из старого кэша отдаётся как прежде
- [ ] `pytest` — 103 теста проходят