### PR TITLE
Replace OCR+Pillow with Gemini image generation for image translation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y ffmpeg fonts-dejavu-core && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY pyproject.toml .

--- a/src/explainer/image_processor.py
+++ b/src/explainer/image_processor.py
@@ -1,168 +1,41 @@
-import io
-import json
+import base64
 import logging
-import statistics
-from pathlib import Path
 
 import httpx
-from PIL import Image, ImageDraw, ImageFont
 
 from src.config import Config
 
-_FONT_SEARCH_PATHS = [
-    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
-    "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
-    "/usr/share/fonts/dejavu/DejaVuSans.ttf",
-]
-
-
-def _load_ttf(size: int) -> ImageFont.FreeTypeFont | None:
-    for path in _FONT_SEARCH_PATHS:
-        if Path(path).exists():
-            try:
-                return ImageFont.truetype(path, size=size)
-            except Exception:
-                continue
-    return None
-
-
 logger = logging.getLogger(__name__)
 
-_DETECT_PROMPT = (
-    "Detect all text visible in this image and translate each piece to Russian. "
-    "Return ONLY valid JSON with no markdown, no explanation, no code block:\n"
-    '[{"text": "original text", "translation": "русский перевод", '
-    '"box": [y_min, x_min, y_max, x_max]}]\n'
-    "box values are integers normalized to 0–1000 "
-    "(y_min/y_max = top/bottom distance from top, x_min/x_max = left/right distance from left). "
-    "If there is no text in the image return exactly: []"
+_TRANSLATE_PROMPT = (
+    "Recreate this image with all English text translated to Russian. "
+    "Keep the exact same visual style, font weight, positioning, colors, and layout. "
+    "Only change the language of the text."
 )
 
 
-async def detect_image_text(image_url: str, config: Config) -> list[dict]:
+async def generate_translated_image(image_url: str, config: Config) -> bytes | None:
     from src.explainer.gemini import _fetch_image
 
     image_part = _fetch_image(image_url)
     if not image_part:
-        return []
+        return None
 
     payload = {
-        "contents": [
-            {
-                "role": "user",
-                "parts": [image_part, {"text": _DETECT_PROMPT}],
-            }
-        ],
-        "generationConfig": {
-            "maxOutputTokens": 2048,
-            "temperature": 0.1,
-            "thinkingConfig": {"thinkingBudget": 0},
-        },
+        "contents": [{"role": "user", "parts": [image_part, {"text": _TRANSLATE_PROMPT}]}],
+        "generationConfig": {"responseModalities": ["IMAGE"]},
     }
     url = (
         "https://generativelanguage.googleapis.com/v1beta/models/"
-        f"gemini-3.1-flash-lite:generateContent?key={config.gemini_api_key}"
+        f"gemini-2.0-flash-preview-image-generation:generateContent?key={config.gemini_api_key}"
     )
     try:
-        async with httpx.AsyncClient(timeout=30) as client:
+        async with httpx.AsyncClient(timeout=60) as client:
             resp = await client.post(url, json=payload)
             resp.raise_for_status()
-        raw = resp.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
-        # Strip markdown code block if model wraps response
-        if raw.startswith("```"):
-            raw = raw.split("```")[1]
-            if raw.startswith("json"):
-                raw = raw[4:]
-        regions = json.loads(raw)
-        if not isinstance(regions, list):
-            return []
-        return [r for r in regions if _valid_region(r)]
+        for part in resp.json()["candidates"][0]["content"]["parts"]:
+            if "inlineData" in part:
+                return base64.b64decode(part["inlineData"]["data"])
     except Exception as e:
-        logger.debug("Image text detection failed: %s", e)
-        return []
-
-
-def _valid_region(r: dict) -> bool:
-    return (
-        isinstance(r, dict) and "translation" in r and "box" in r and isinstance(r["box"], list) and len(r["box"]) == 4
-    )
-
-
-def _median_color(pixels: list[tuple]) -> tuple[int, int, int]:
-    if not pixels:
-        return (255, 255, 255)
-    r = statistics.median(p[0] for p in pixels)
-    g = statistics.median(p[1] for p in pixels)
-    b = statistics.median(p[2] for p in pixels)
-    return (int(r), int(g), int(b))
-
-
-def _contrasting(color: tuple[int, int, int]) -> tuple[int, int, int]:
-    luminance = 0.299 * color[0] + 0.587 * color[1] + 0.114 * color[2]
-    return (0, 0, 0) if luminance > 128 else (255, 255, 255)
-
-
-def _make_font(size: int) -> ImageFont.ImageFont:
-    return _load_ttf(size) or ImageFont.load_default(size=size)
-
-
-def _fit_text(draw: ImageDraw.ImageDraw, text: str, box_w: int, box_h: int) -> tuple[ImageFont.ImageFont, int, int]:
-    for size in range(max(8, int(box_h * 0.4)), 7, -1):
-        font = _make_font(size)
-        bbox = draw.textbbox((0, 0), text, font=font)
-        tw = bbox[2] - bbox[0]
-        th = bbox[3] - bbox[1]
-        if tw <= box_w and th <= box_h:
-            return font, tw, th
-    font = _make_font(8)
-    bbox = draw.textbbox((0, 0), text, font=font)
-    return font, bbox[2] - bbox[0], bbox[3] - bbox[1]
-
-
-def overlay_translations(image_bytes: bytes, regions: list[dict]) -> bytes:
-    img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
-    w, h = img.size
-    draw = ImageDraw.Draw(img)
-
-    for region in regions:
-        box = region["box"]
-        text = region["translation"]
-
-        y_min = max(0, int(box[0] * h / 1000))
-        x_min = max(0, int(box[1] * w / 1000))
-        y_max = min(h, int(box[2] * h / 1000))
-        x_max = min(w, int(box[3] * w / 1000))
-
-        if x_max <= x_min or y_max <= y_min:
-            continue
-
-        # Sample border pixels to estimate background
-        border: list[tuple] = []
-        for x in range(x_min, x_max):
-            if y_min < h:
-                border.append(img.getpixel((x, y_min)))
-            if y_max - 1 < h:
-                border.append(img.getpixel((x, y_max - 1)))
-        for y in range(y_min, y_max):
-            if x_min < w:
-                border.append(img.getpixel((x_min, y)))
-            if x_max - 1 < w:
-                border.append(img.getpixel((x_max - 1, y)))
-
-        bg = _median_color(border)
-        fg = _contrasting(bg)
-
-        draw.rectangle([x_min, y_min, x_max, y_max], fill=bg)
-
-        box_w = x_max - x_min - 4
-        box_h = y_max - y_min - 4
-        font, tw, th = _fit_text(draw, text, box_w, box_h)
-
-        tx = x_min + (box_w - tw) // 2 + 2
-        ty = y_min + (box_h - th) // 2 + 2
-        draw.text((tx, ty), text, fill=fg, font=font)
-
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=90)
-    return buf.getvalue()
+        logger.debug("Gemini image generation failed: %s", e)
+    return None

--- a/src/webapp/server.py
+++ b/src/webapp/server.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 
-import httpx
 import uvicorn
 from fastapi import FastAPI, Form
 from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
@@ -19,7 +18,7 @@ from src.db import (
     save_translated_image,
 )
 from src.explainer.gemini import _SYSTEM_PROMPT_DEFAULT, stream_explanation
-from src.explainer.image_processor import detect_image_text, overlay_translations
+from src.explainer.image_processor import generate_translated_image
 
 logger = logging.getLogger(__name__)
 
@@ -280,12 +279,8 @@ def create_app(config: Config) -> FastAPI:
                     if not image_data:
                         image_url = post.get("content_url") or post.get("preview_url")
                         if image_url:
-                            regions = await detect_image_text(image_url, config)
-                            if regions:
-                                async with httpx.AsyncClient(timeout=15) as img_client:
-                                    raw_resp = await img_client.get(image_url, follow_redirects=True)
-                                raw_resp.raise_for_status()
-                                image_data = overlay_translations(raw_resp.content, regions)
+                            image_data = await generate_translated_image(image_url, config)
+                            if image_data:
                                 await save_translated_image(reddit_id, image_data)
                     if image_data:
                         yield sse("image", f"/api/image/{reddit_id}")

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -126,7 +126,7 @@ async def test_explain_stream_caches_only_complete_response():
         patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None),
         patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post),
         patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None),
-        patch("src.webapp.server.detect_image_text", new_callable=AsyncMock, return_value=[]),
+        patch("src.webapp.server.generate_translated_image", new_callable=AsyncMock, return_value=None),
         patch("src.webapp.server.stream_explanation", side_effect=fake_stream),
         patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save,
     ):
@@ -145,7 +145,7 @@ async def test_explain_stream_does_not_cache_truncated_response():
         patch("src.webapp.server.get_explanation", new_callable=AsyncMock, return_value=None),
         patch("src.webapp.server.get_post", new_callable=AsyncMock, return_value=fake_post),
         patch("src.webapp.server.get_translated_image", new_callable=AsyncMock, return_value=None),
-        patch("src.webapp.server.detect_image_text", new_callable=AsyncMock, return_value=[]),
+        patch("src.webapp.server.generate_translated_image", new_callable=AsyncMock, return_value=None),
         patch("src.webapp.server.stream_explanation", side_effect=fake_stream),
         patch("src.webapp.server.save_explanation", new_callable=AsyncMock) as mock_save,
     ):


### PR DESCRIPTION
## Summary

- Удалён весь пайплайн OCR+Pillow (`detect_image_text`, `overlay_translations`, шрифты, bounding boxes)
- Вместо него — одна функция `generate_translated_image`: отправляет картинку в `gemini-2.0-flash-preview-image-generation` с просьбой перевести текст на русский, сохранив визуальный стиль
- Gemini сам воссоздаёт картинку с правильным шрифтом, цветами и раскладкой — без артефактов
- Убран `fonts-dejavu-core` из Dockerfile
- Упрощён пайплайн в `server.py`: было 8 строк, стало 4

## Test plan

- [ ] После деплоя: открыть AI-explanation для поста с мемом — картинка с русским текстом в оригинальном стиле
- [ ] `pytest` — 103 теста проходят