### PR TITLE
Fix Gemini image generation model name

### DIFF
--- a/src/explainer/image_processor.py
+++ b/src/explainer/image_processor.py
@@ -27,15 +27,19 @@ async def generate_translated_image(image_url: str, config: Config) -> bytes | N
     }
     url = (
         "https://generativelanguage.googleapis.com/v1beta/models/"
-        f"gemini-2.0-flash-preview-image-generation:generateContent?key={config.gemini_api_key}"
+        f"gemini-3.1-flash-image-preview:generateContent?key={config.gemini_api_key}"
     )
     try:
-        async with httpx.AsyncClient(timeout=60) as client:
+        async with httpx.AsyncClient(timeout=120) as client:
             resp = await client.post(url, json=payload)
-            resp.raise_for_status()
+        if resp.status_code != 200:
+            logger.warning("Gemini image gen HTTP %s: %s", resp.status_code, resp.text[:300])
+            return None
         for part in resp.json()["candidates"][0]["content"]["parts"]:
             if "inlineData" in part:
                 return base64.b64decode(part["inlineData"]["data"])
+            if "inline_data" in part:
+                return base64.b64decode(part["inline_data"]["data"])
     except Exception as e:
-        logger.debug("Gemini image generation failed: %s", e)
+        logger.warning("Gemini image generation failed: %s", e)
     return None


### PR DESCRIPTION
## Summary

Модель `gemini-2.0-flash-preview-image-generation` не существует (API возвращает 404). Правильное имя — `gemini-3.1-flash-image-preview` (в соответствии со стилем `gemini-3.1-flash-lite` который уже используется для текста).

- Исправлено имя модели
- Уровень логирования ошибок повышен с DEBUG до WARNING (в production DEBUG не виден)
- Логируется текст ошибки API при non-200 ответе
- Поддерживается и `inlineData`, и `inline_data` в ответе
- Таймаут увеличен с 60 до 120 секунд (image generation медленнее текста)

## Test plan

Картинка перегенерируется при следующем открытии AI-explanation (translated_image в DB уже сброшен).