### PR TITLE
Add no-cache headers for Telegram Web Desktop compatibility

### DIFF
--- a/src/webapp/server.py
+++ b/src/webapp/server.py
@@ -186,8 +186,8 @@ def create_app(config: Config) -> FastAPI:
     app = FastAPI(docs_url=None, redoc_url=None)
 
     @app.get("/", response_class=HTMLResponse)
-    async def index() -> str:
-        return _MINI_APP_HTML
+    async def index() -> HTMLResponse:
+        return HTMLResponse(_MINI_APP_HTML, headers={"Cache-Control": "no-store, no-cache, must-revalidate"})
 
     @app.get("/health")
     async def health() -> dict:
@@ -311,7 +311,15 @@ def create_app(config: Config) -> FastAPI:
                 await save_explanation(reddit_id, text)
             yield sse("done", "")
 
-        return StreamingResponse(event_stream(), media_type="text/event-stream")
+        return StreamingResponse(
+            event_stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
 
     @app.get("/api/explain")
     async def explain(reddit_id: str) -> JSONResponse:


### PR DESCRIPTION
## Summary

Telegram Web Desktop крашит WebView (на мобильном работает). Гипотеза — старая закэшированная версия HTML/JS, либо буферизация SSE-стрима Railway edge proxy.

- HTML страница: `Cache-Control: no-store, no-cache, must-revalidate` — Telegram больше не будет использовать устаревший HTML
- SSE-эндпоинт: `Cache-Control: no-cache, no-transform`, `X-Accel-Buffering: no`, `Connection: keep-alive` — предотвращает буферизацию проксями (Railway edge, любые промежуточные)

## Test plan

После деплоя на десктопе: жёсткий перезагруз Telegram Web (Ctrl+Shift+R) → открыть AI-explanation → проверить что не падает.