### PR TITLE
Filter image-text blocks server-side when image overlay is shown

### DIFF
--- a/src/explainer/image_processor.py
+++ b/src/explainer/image_processor.py
@@ -105,6 +105,43 @@ def _valid_region(r: dict) -> bool:
     )
 
 
+def _word_overlap(a: str, b: str) -> float:
+    """Jaccard similarity of word sets (case-insensitive)."""
+    wa, wb = set(a.lower().split()), set(b.lower().split())
+    if not wa or not wb:
+        return 0.0
+    return len(wa & wb) / max(len(wa), len(wb))
+
+
+def filter_image_text_blocks(text: str, image_regions: list[dict] | None, has_selftext: bool) -> str:
+    """
+    Strip blocks that contain text from the image overlay (already shown as a separate image).
+
+    Gemini often ignores the prompt and translates image text anyway in a format like:
+        original text
+        > *перевод*
+    This format is identical to section 3 (post text). To distinguish:
+    - If image_regions are available: strip blocks whose original line overlaps with any OCR'd region.
+    - If post has no selftext: section 3 cannot exist, so strip ALL non-bold translation blocks.
+    """
+    image_originals = [r.get("text", "").strip() for r in (image_regions or []) if r.get("text")]
+
+    blocks = text.split("\n\n")
+    filtered: list[str] = []
+    for block in blocks:
+        lines = block.split("\n")
+        if len(lines) >= 2 and lines[1].lstrip().startswith("> *") and not lines[0].lstrip().startswith("**"):
+            original = lines[0].strip()
+            # Strip if matches a known image region
+            if image_originals and any(_word_overlap(original, img) > 0.5 for img in image_originals):
+                continue
+            # Strip if no selftext exists (section 3 impossible → this must be section 4)
+            if not has_selftext:
+                continue
+        filtered.append(block)
+    return "\n\n".join(filtered)
+
+
 def _inpaint_regions(img_bgr: np.ndarray, regions_px: list[tuple[int, int, int, int]]) -> np.ndarray:
     """Use cv2.inpaint to reconstruct background where original text was."""
     h, w = img_bgr.shape[:2]

--- a/src/webapp/server.py
+++ b/src/webapp/server.py
@@ -19,7 +19,7 @@ from src.db import (
     save_translated_image,
 )
 from src.explainer.gemini import _SYSTEM_PROMPT_DEFAULT, stream_explanation
-from src.explainer.image_processor import detect_image_text, overlay_translations
+from src.explainer.image_processor import detect_image_text, filter_image_text_blocks, overlay_translations
 
 logger = logging.getLogger(__name__)
 
@@ -274,18 +274,19 @@ def create_app(config: Config) -> FastAPI:
 
             # Try image text translation for single-image posts
             skip_image_text = False
+            image_regions: list[dict] | None = None
             if post.get("post_type") == "image":
                 try:
                     image_data = await get_translated_image(reddit_id)
                     if not image_data:
                         image_url = post.get("content_url") or post.get("preview_url")
                         if image_url:
-                            regions = await detect_image_text(image_url, post, config)
-                            if regions:
+                            image_regions = await detect_image_text(image_url, post, config)
+                            if image_regions:
                                 async with httpx.AsyncClient(timeout=15) as img_client:
                                     raw_resp = await img_client.get(image_url, follow_redirects=True)
                                 raw_resp.raise_for_status()
-                                image_data = overlay_translations(raw_resp.content, regions)
+                                image_data = overlay_translations(raw_resp.content, image_regions)
                                 await save_translated_image(reddit_id, image_data)
                     if image_data:
                         yield sse("image", f"/api/image/{reddit_id}")
@@ -303,9 +304,20 @@ def create_app(config: Config) -> FastAPI:
 
             full_text = ""
             try:
-                async for chunk in stream_explanation(config, post, skip_image_text=skip_image_text):
-                    full_text += chunk
-                    yield sse("chunk", chunk)
+                if skip_image_text:
+                    # Buffer the whole response, filter out blocks that duplicate the image overlay,
+                    # then emit the cleaned text as a single chunk. Gemini ignores prompt-level
+                    # forbidding, so server-side filtering is the reliable fix.
+                    async for chunk in stream_explanation(config, post, skip_image_text=True):
+                        full_text += chunk
+                    full_text = filter_image_text_blocks(
+                        full_text, image_regions, has_selftext=bool(post.get("selftext"))
+                    )
+                    yield sse("chunk", full_text)
+                else:
+                    async for chunk in stream_explanation(config, post, skip_image_text=False):
+                        full_text += chunk
+                        yield sse("chunk", chunk)
             except Exception as e:
                 logger.warning("Gemini stream error for %s: %s", reddit_id, e)
                 yield sse("error", "Не удалось сгенерировать объяснение.")


### PR DESCRIPTION
## Summary

PR #67 пытался убрать дублирование через строгий запрет в промпте — Gemini это проигнорировал. Делаем надёжный server-side фильтр.

### Логика

Когда `skip_image_text=True` (картинка-перевод создана) — буферизуем ответ Gemini целиком, выкидываем блоки с переводом текста из картинки, отдаём очищенный текст одним SSE-чанком.

### Как определяем «блок с текстом из картинки»

Блок формата:
```
plain text
> *перевод*
```
(без `**жирного**` в первой строке — это отличает от раздела 2/заголовка)

Решаем так:
1. **Если есть OCR-регионы** (`detect_image_text` отработал в этом запросе): сравниваем оригинал блока со словами из регионов — Jaccard > 0.5 → выкидываем
2. **Если поста без selftext**: раздел 3 невозможен, любой такой блок — это раздел 4 → выкидываем

### Trade-off

Стриминг для постов с картинкой пропадает: shimmer держится пока Gemini не закончит (~3-5 секунд), потом сразу весь очищенный текст. Для не-image постов стриминг остаётся.

## Test plan

- [x] `pytest` — 103 теста проходят
- [x] Локальный тест фильтра на реальном кэшированном тексте: разделы 1-2 сохраняются, раздел 4 удаляется
- [ ] После деплоя + cleanup кэша: открыть пост с картинкой → раздел 4 не появляется