### PR TITLE
Authenticate Reddit proxy via OAuth and add retry to fetch_top_posts

### DIFF
--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,3 +1,46 @@
+// Cached OAuth token, shared across requests within the same isolate.
+let tokenCache = { value: null, expiresAt: 0 };
+
+async function getToken(env) {
+  const now = Date.now();
+  if (tokenCache.value && now < tokenCache.expiresAt - 60_000) {
+    return tokenCache.value;
+  }
+
+  const auth = btoa(`${env.REDDIT_CLIENT_ID}:${env.REDDIT_CLIENT_SECRET}`);
+  const response = await fetch("https://www.reddit.com/api/v1/access_token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${auth}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": env.USER_AGENT || "reddit-scrapper/0.1",
+    },
+    body: "grant_type=client_credentials",
+  });
+
+  if (!response.ok) {
+    throw new Error(`OAuth token request failed: ${response.status}`);
+  }
+
+  const data = await response.json();
+  tokenCache = {
+    value: data.access_token,
+    expiresAt: now + data.expires_in * 1000,
+  };
+  return tokenCache.value;
+}
+
+async function fetchReddit(redditUrl, token, env) {
+  return fetch(redditUrl, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": env.USER_AGENT || "reddit-scrapper/0.1",
+      Accept: "application/json",
+      "Accept-Language": "en-US,en;q=0.9",
+    },
+  });
+}
+
 export default {
   async fetch(request, env) {
     const secret = request.headers.get("X-Proxy-Secret");
@@ -6,16 +49,35 @@ export default {
     }
 
     const url = new URL(request.url);
-    const redditUrl = new URL("https://www.reddit.com" + url.pathname);
+    // Authenticated requests go to oauth.reddit.com instead of www.reddit.com.
+    const redditUrl = new URL("https://oauth.reddit.com" + url.pathname);
     url.searchParams.forEach((value, key) => redditUrl.searchParams.set(key, value));
 
-    const response = await fetch(redditUrl.toString(), {
-      headers: {
-        "User-Agent": env.USER_AGENT || "reddit-scrapper/0.1",
-        "Accept": "application/json",
-        "Accept-Language": "en-US,en;q=0.9",
-      },
-    });
+    let token;
+    try {
+      token = await getToken(env);
+    } catch (err) {
+      return new Response(JSON.stringify({ error: String(err) }), {
+        status: 502,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    let response = await fetchReddit(redditUrl.toString(), token, env);
+
+    // On 401 the token may be stale — refresh once and retry.
+    if (response.status === 401) {
+      tokenCache = { value: null, expiresAt: 0 };
+      token = await getToken(env);
+      response = await fetchReddit(redditUrl.toString(), token, env);
+    }
+
+    // On 429/5xx do a single short backoff retry.
+    if (response.status === 429 || response.status >= 500) {
+      const retryAfter = parseInt(response.headers.get("Retry-After") || "2", 10);
+      await new Promise((r) => setTimeout(r, Math.min(retryAfter, 5) * 1000));
+      response = await fetchReddit(redditUrl.toString(), token, env);
+    }
 
     const body = await response.text();
     return new Response(body, {

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -116,8 +116,15 @@ async def fetch_top_posts(config: Config) -> list[dict]:
         url = REDDIT_URL
 
     async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-        response = await client.get(url, params=params, headers=headers)
-        response.raise_for_status()
+        for attempt in range(3):
+            response = await client.get(url, params=params, headers=headers)
+            if response.status_code in (403, 429) and attempt < 2:
+                retry_after = int(response.headers.get("Retry-After", (attempt + 1) * 10))
+                logger.info("Reddit %d fetching posts, retrying in %ds", response.status_code, retry_after)
+                await asyncio.sleep(retry_after)
+                continue
+            response.raise_for_status()
+            break
 
     children = response.json().get("data", {}).get("children", [])
     posts = []


### PR DESCRIPTION
## Problem

Scraping stopped pulling new posts. Production logs showed every scrape cycle failing with `403 Forbidden` / `429 Too Many Requests` from the Cloudflare proxy worker. The unpublished queue in Postgres drained and Telegram posts stopped.

Root cause: the worker fetched anonymous `www.reddit.com`. Reddit heavily throttles/blocks unauthenticated requests from datacenter and Cloudflare egress IPs, so the shared anonymous limit was exhausted (429) or the IP blocked (403).

## Changes

- **`cloudflare/worker.js`**: fetch via Reddit OAuth (`client_credentials`) against `oauth.reddit.com` with a `Bearer` token. Token is cached per isolate; refresh-and-retry on 401; single backoff retry on 429/5xx. Same `X-Proxy-Secret` interface — no bot-side change needed.
- **`src/scraper/reddit.py`**: add 403/429 retry with backoff to `fetch_top_posts`, matching the existing pattern in `fetch_top_comments`, so a transient block no longer skips an entire scrape cycle.

## Deploy note

The worker now needs `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` env vars (set as Cloudflare secrets) before deploy.

## Testing

`ruff check` clean; full suite 103 passed.