### PR TITLE
Route Reddit proxy through residential scraping service

### DIFF
--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,3 +1,33 @@
+// Routes anonymous Reddit requests through a residential scraping-proxy service
+// (e.g. ScraperAPI) so they egress from a residential IP that Reddit does not
+// block, instead of the datacenter IP of this Worker.
+//
+// Required env:
+//   PROXY_SECRET     shared secret the bot sends in X-Proxy-Secret
+//   SCRAPER_API_KEY  API key of the scraping-proxy service
+// Optional env:
+//   SCRAPER_BASE_URL endpoint of the service (default ScraperAPI)
+//   USER_AGENT       User-Agent forwarded to Reddit
+
+const DEFAULT_SCRAPER_BASE = "https://api.scraperapi.com/";
+
+function buildScraperUrl(env, targetUrl) {
+  const base = new URL(env.SCRAPER_BASE_URL || DEFAULT_SCRAPER_BASE);
+  base.searchParams.set("api_key", env.SCRAPER_API_KEY);
+  base.searchParams.set("url", targetUrl);
+  return base.toString();
+}
+
+async function fetchViaProxy(env, targetUrl) {
+  return fetch(buildScraperUrl(env, targetUrl), {
+    headers: {
+      "User-Agent": env.USER_AGENT || "reddit-scrapper/0.1",
+      Accept: "application/json",
+      "Accept-Language": "en-US,en;q=0.9",
+    },
+  });
+}
+
 export default {
   async fetch(request, env) {
     const secret = request.headers.get("X-Proxy-Secret");
@@ -5,17 +35,26 @@ export default {
       return new Response("Unauthorized", { status: 401 });
     }
 
+    if (!env.SCRAPER_API_KEY) {
+      return new Response(JSON.stringify({ error: "SCRAPER_API_KEY not configured" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     const url = new URL(request.url);
     const redditUrl = new URL("https://www.reddit.com" + url.pathname);
     url.searchParams.forEach((value, key) => redditUrl.searchParams.set(key, value));
+    const target = redditUrl.toString();
 
-    const response = await fetch(redditUrl.toString(), {
-      headers: {
-        "User-Agent": env.USER_AGENT || "reddit-scrapper/0.1",
-        "Accept": "application/json",
-        "Accept-Language": "en-US,en;q=0.9",
-      },
-    });
+    let response = await fetchViaProxy(env, target);
+
+    // On 429/5xx do a single short backoff retry.
+    if (response.status === 429 || response.status >= 500) {
+      const retryAfter = parseInt(response.headers.get("Retry-After") || "2", 10);
+      await new Promise((r) => setTimeout(r, Math.min(retryAfter, 5) * 1000));
+      response = await fetchViaProxy(env, target);
+    }
 
     const body = await response.text();
     return new Response(body, {

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -116,8 +116,15 @@ async def fetch_top_posts(config: Config) -> list[dict]:
         url = REDDIT_URL
 
     async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-        response = await client.get(url, params=params, headers=headers)
-        response.raise_for_status()
+        for attempt in range(3):
+            response = await client.get(url, params=params, headers=headers)
+            if response.status_code in (403, 429) and attempt < 2:
+                retry_after = int(response.headers.get("Retry-After", (attempt + 1) * 10))
+                logger.info("Reddit %d fetching posts, retrying in %ds", response.status_code, retry_after)
+                await asyncio.sleep(retry_after)
+                continue
+            response.raise_for_status()
+            break
 
     children = response.json().get("data", {}).get("children", [])
     posts = []


### PR DESCRIPTION
## Problem

Scraping stopped: every cycle failed with `403`/`429` from the Cloudflare proxy worker. Root cause is IP-based — Reddit blocks anonymous access from datacenter/Cloudflare egress IPs, so the unpublished queue drained and Telegram posts stopped.

## Approach

Keep anonymous Reddit access (no Reddit app / OAuth), but make the worker egress from a **residential IP** via a scraping-proxy service (ScraperAPI-compatible), which Reddit does not block.

## Changes

- **`cloudflare/worker.js`**: instead of fetching Reddit directly, wrap the target URL through a scraping-proxy endpoint (`?api_key=…&url=…`). Vendor-neutral via `SCRAPER_BASE_URL` (default ScraperAPI); single backoff retry on 429/5xx. Same `X-Proxy-Secret` interface — no bot-side change.
- **`src/scraper/reddit.py`**: add 403/429 retry with backoff to `fetch_top_posts`, matching `fetch_top_comments`, so a transient block no longer skips an entire scrape cycle.

## Deploy note

Worker now needs `SCRAPER_API_KEY` (and optional `SCRAPER_BASE_URL`) as Cloudflare secrets. No Railway change.

## Testing

`ruff check` clean; full suite 103 passed.