### PR TITLE
Fix gallery image downloads (signed preview.redd.it URLs)

### DIFF
--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import logging
 import re
 from datetime import UTC, datetime
@@ -15,7 +16,9 @@ logger = logging.getLogger(__name__)
 OLD_REDDIT = "https://old.reddit.com"
 # old.reddit blocks bot-looking User-Agents, so always present as a browser.
 BROWSER_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-_GALLERY_IMG_RE = re.compile(r"https://(?:preview|i)\.redd\.it/[A-Za-z0-9._-]+\.(?:jpg|jpeg|png|webp|gif)")
+# Capture the full URL including the signed query string — preview.redd.it images
+# return 403 without their `?...&s=<sig>` signature.
+_GALLERY_IMG_RE = re.compile(r"""https://(?:preview|i)\.redd\.it/[^\s"'<>]+\.(?:jpg|jpeg|png|webp|gif)[^\s"'<>]*""")
 
 
 def _headers() -> dict:
@@ -132,11 +135,23 @@ async def _fetch_gallery_images(client: httpx.AsyncClient, post: dict) -> list[s
     except Exception:
         logger.warning("Failed to fetch gallery images for %s", post["reddit_id"])
         return None
-    seen: list[str] = []
+    # preview.redd.it serves several variants per image: unsigned thumbnails (no `s=`,
+    # which 403) plus signed copies at different widths. Keep the largest signed variant.
+    order: list[str] = []
+    best: dict[str, tuple[int, str]] = {}
     for match in _GALLERY_IMG_RE.findall(response.text):
-        if match not in seen:
-            seen.append(match)
-    return seen[:20] or None
+        url = html.unescape(match)
+        if "preview.redd.it" in url and not re.search(r"[?&]s=", url):
+            continue
+        path = url.split("?", 1)[0]
+        width_match = re.search(r"[?&]width=(\d+)", url)
+        width = int(width_match.group(1)) if width_match else 0
+        if path not in best:
+            order.append(path)
+            best[path] = (width, url)
+        elif width > best[path][0]:
+            best[path] = (width, url)
+    return [best[path][1] for path in order][:20] or None
 
 
 async def fetch_top_posts(config: Config) -> list[dict]:

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -76,16 +76,24 @@ async def test_fetch_top_comments_returns_empty_on_error():
 
 
 @respx.mock
-async def test_fetch_gallery_images_extracts_unique_urls():
-    html = (
-        '<a href="https://preview.redd.it/aaa.jpg">x</a>'
-        " text https://preview.redd.it/bbb.png more"
-        ' <a href="https://preview.redd.it/aaa.jpg">dup</a>'
+async def test_fetch_gallery_images_picks_largest_signed_variant():
+    # Unsigned thumbnail (no s=) is skipped; the largest signed width wins even when a
+    # smaller signed variant appears first; &amp; decoded; i.redd.it kept without a signature.
+    page_html = (
+        '<a href="https://preview.redd.it/aaa.jpg?width=108&amp;s=SIG_SMALL">small</a>'
+        '<a href="https://preview.redd.it/aaa.jpg?width=140&amp;auto=webp">unsigned thumb</a>'
+        '<a href="https://preview.redd.it/aaa.jpg?width=1170&amp;s=SIG_BIG">big</a>'
+        " text https://preview.redd.it/bbb.png?s=SIG3 more"
+        '<a href="https://i.redd.it/ccc.jpg">direct</a>'
     )
-    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=html))
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=page_html))
     async with httpx.AsyncClient() as client:
         urls = await _fetch_gallery_images(client, SAMPLE_POST)
-    assert urls == ["https://preview.redd.it/aaa.jpg", "https://preview.redd.it/bbb.png"]
+    assert urls == [
+        "https://preview.redd.it/aaa.jpg?width=1170&s=SIG_BIG",
+        "https://preview.redd.it/bbb.png?s=SIG3",
+        "https://i.redd.it/ccc.jpg",
+    ]
 
 
 @respx.mock


### PR DESCRIPTION
## Problem

After switching to old.reddit scraping (#71), gallery posts published but their images failed to download with `403 Forbidden` from `preview.redd.it`. Two causes:

1. The extraction regex truncated the URL at the file extension, dropping the required `?...&s=<signature>` — `preview.redd.it` returns 403 without its signature.
2. The page also contains unsigned thumbnail variants (e.g. 140px) and multiple signed sizes; dedup-by-path kept the *first* match, which was often an unsigned or tiny thumbnail.

## Fix (`_fetch_gallery_images`)

- Capture the full URL including the query string, and HTML-unescape `&amp;`.
- Skip unsigned `preview.redd.it` variants (no `s=`); keep `i.redd.it` as-is (needs no signature).
- Among signed variants of the same image, keep the **largest `width=`**.

## Testing

- `ruff format --check` + `ruff check` clean; full suite **103 passed**.
- Verified live against old.reddit: gallery images now resolve to full-res (~1170px) signed URLs and download with **200** (were 403).