### PR TITLE
Post image/gif comment media (extract from old.reddit HTML)

### DIFF
--- a/src/publisher/telegram.py
+++ b/src/publisher/telegram.py
@@ -552,7 +552,13 @@ async def publish_comment(
     reply_to_message_id: int,
 ) -> int | None:
     """Send one comment as reply in the discussion group."""
-    media_url, clean_body, media_type = _extract_media_url(comment["body"])
+    # Comments scraped from old.reddit carry the media URL directly (the body is already
+    # clean text); fall back to parsing markdown bodies from other sources.
+    if comment.get("media_url"):
+        media_url, media_type = comment["media_url"], comment.get("media_type")
+        clean_body = comment["body"]
+    else:
+        media_url, clean_body, media_type = _extract_media_url(comment["body"])
     caption = _format_comment(comment, body_override=clean_body)
 
     async with httpx.AsyncClient(timeout=None) as client:

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -183,6 +183,27 @@ def _parse_comment_score(thing) -> int:
     return 0
 
 
+def _extract_comment_media(md_tag) -> tuple[str | None, str | None]:
+    """Pull an image/gif URL out of a comment body's rendered HTML.
+
+    old.reddit renders a gif/emote as ``<img src=...>`` and a Reddit-uploaded image as
+    ``<a href=...><image></a>``. ``.get_text()`` loses both, so read the URLs directly.
+    """
+    img = md_tag.find("img")
+    if img and img.get("src"):
+        return html.unescape(img["src"]), "gif"
+    for anchor in md_tag.find_all("a", href=True):
+        if anchor.get_text(strip=True) == "<image>":
+            href = html.unescape(anchor["href"])
+            return href, ("gif" if ".gif" in href.lower() else "image")
+    return None, None
+
+
+def _clean_comment_text(md_tag) -> str:
+    """Visible comment text with the literal ``<image>`` media placeholder removed."""
+    return md_tag.get_text("\n", strip=True).replace("<image>", "").strip()
+
+
 async def fetch_top_comments(config: Config, post: dict, limit: int = 5) -> list[dict]:
     """Fetch top-level comments sorted by score from old.reddit HTML."""
     permalink = post["url"].removeprefix("https://reddit.com")
@@ -204,10 +225,21 @@ async def fetch_top_comments(config: Config, post: dict, limit: int = 5) -> list
             if not author or author == "[deleted]":
                 continue
             body_tag = thing.select_one("div.entry div.usertext-body div.md")
-            body = body_tag.get_text("\n", strip=True) if body_tag else ""
-            if body in ("", "[removed]", "[deleted]"):
+            if not body_tag:
                 continue
-            comments.append({"author": author, "body": body, "score": _parse_comment_score(thing)})
+            media_url, media_type = _extract_comment_media(body_tag)
+            body = _clean_comment_text(body_tag)
+            if not media_url and body in ("", "[removed]", "[deleted]"):
+                continue
+            comments.append(
+                {
+                    "author": author,
+                    "body": body,
+                    "score": _parse_comment_score(thing),
+                    "media_url": media_url,
+                    "media_type": media_type,
+                }
+            )
 
         comments.sort(key=lambda x: x["score"], reverse=True)
         comments = comments[:limit]

--- a/tests/fixtures/old_reddit_comments.html
+++ b/tests/fixtures/old_reddit_comments.html
@@ -20,6 +20,27 @@
       </div>
     </div>
 
+    <div class="thing comment" data-author="imguser">
+      <div class="entry">
+        <span class="score unvoted" title="500 points">500 points</span>
+        <div class="usertext-body"><div class="md"><p><a href="https://preview.redd.it/img1.png?width=1170&amp;s=SIGIMG" target="_blank">&lt;image&gt;</a></p></div></div>
+      </div>
+    </div>
+
+    <div class="thing comment" data-author="gifuser">
+      <div class="entry">
+        <span class="score unvoted" title="200 points">200 points</span>
+        <div class="usertext-body"><div class="md"><p><a href="https://giphy.com/gifs/abc" target="_blank"><img src="https://external-preview.redd.it/gif1.gif?width=200&amp;s=SIGGIF" width="200" height="200"/></a></p></div></div>
+      </div>
+    </div>
+
+    <div class="thing comment" data-author="mixeduser">
+      <div class="entry">
+        <span class="score unvoted" title="50 points">50 points</span>
+        <div class="usertext-body"><div class="md"><p><a href="https://preview.redd.it/img2.jpeg?s=SIGMIX" target="_blank">&lt;image&gt;</a></p><p>nice pic</p></div></div>
+      </div>
+    </div>
+
     <div class="thing comment" data-author="low">
       <div class="entry">
         <span class="score unvoted" title="3 points">3 points</span>

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -44,7 +44,9 @@ async def test_fetch_top_posts_skips_promoted_and_deleted():
 async def test_fetch_top_comments_parses_and_sorts():
     respx.get(COMMENTS_URL).mock(return_value=Response(200, html=COMMENTS_HTML))
     comments = await fetch_top_comments(CONFIG, SAMPLE_POST)
-    assert [c["author"] for c in comments] == ["high", "low"]
+    scores = [c["score"] for c in comments]
+    assert scores == sorted(scores, reverse=True)
+    assert comments[0]["author"] == "high"
     assert comments[0]["score"] == 999
 
 
@@ -70,6 +72,43 @@ async def test_fetch_top_comments_ignores_nested_replies():
 async def test_fetch_top_comments_returns_empty_on_error():
     respx.get(COMMENTS_URL).mock(return_value=Response(500))
     assert await fetch_top_comments(CONFIG, SAMPLE_POST) == []
+
+
+@respx.mock
+async def test_fetch_top_comments_extracts_image_media():
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=COMMENTS_HTML))
+    comments = await fetch_top_comments(CONFIG, SAMPLE_POST)
+    img = next(c for c in comments if c["author"] == "imguser")
+    assert img["media_type"] == "image"
+    assert img["media_url"] == "https://preview.redd.it/img1.png?width=1170&s=SIGIMG"
+    assert img["body"] == ""  # the literal <image> placeholder is stripped
+
+
+@respx.mock
+async def test_fetch_top_comments_extracts_gif_media():
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=COMMENTS_HTML))
+    comments = await fetch_top_comments(CONFIG, SAMPLE_POST)
+    gif = next(c for c in comments if c["author"] == "gifuser")
+    assert gif["media_type"] == "gif"
+    assert gif["media_url"] == "https://external-preview.redd.it/gif1.gif?width=200&s=SIGGIF"
+
+
+@respx.mock
+async def test_fetch_top_comments_media_with_text_kept():
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=COMMENTS_HTML))
+    comments = await fetch_top_comments(CONFIG, SAMPLE_POST)
+    mixed = next(c for c in comments if c["author"] == "mixeduser")
+    assert mixed["media_url"] == "https://preview.redd.it/img2.jpeg?s=SIGMIX"
+    assert mixed["body"] == "nice pic"
+
+
+@respx.mock
+async def test_fetch_top_comments_text_only_has_no_media():
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=COMMENTS_HTML))
+    comments = await fetch_top_comments(CONFIG, SAMPLE_POST)
+    high = next(c for c in comments if c["author"] == "high")
+    assert high["media_url"] is None
+    assert high["media_type"] is None
 
 
 # --- _fetch_gallery_images ---


### PR DESCRIPTION
## Problem

Comments that contain an image or gif on Reddit were posting the literal text `<image>` (or nothing) in the Telegram discussion group instead of the media.

Cause: old.reddit renders comment media as HTML our scraper threw away —
- Reddit-uploaded image: `<a href="https://preview.redd.it/...?...&s=SIG">&lt;image&gt;</a>` → `.get_text()` returns the literal `<image>`.
- Giphy/gif: `<a ...><img src="https://external-preview.redd.it/....gif?...&s=SIG"></a>` → `.get_text()` returns empty, so the comment was dropped.

The publisher already supports sending comment media (`sendPhoto`/`sendAnimation`), but it was parsing the old markdown body format, which HTML extraction no longer produces.

## Fix

- **`fetch_top_comments`** now extracts the media URL from the comment's rendered HTML: `<img src>` for gifs/emotes, or the `<a href>` behind an `<image>` placeholder for Reddit images (signed `preview.redd.it` URLs, HTML-unescaped). The comment dict gains `media_url`/`media_type`, the body is cleaned of the `<image>` placeholder, and media-only comments are no longer skipped as empty.
- **`publish_comment`** uses the scraper-provided `media_url`/`media_type` when present, falling back to the existing markdown parser.

## Testing

- `ruff format --check` + `ruff check` clean; full suite **107 passed** (4 new comment-media tests).
- Verified live against a real thread: 3 media comments extracted (2 images, 1 gif), all URLs download **200** (480KB / 224KB / 951KB), bodies cleaned.