### PR TITLE
Fix galleries pulling in comment/read-next images

### DIFF
--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -16,9 +16,10 @@ logger = logging.getLogger(__name__)
 OLD_REDDIT = "https://old.reddit.com"
 # old.reddit blocks bot-looking User-Agents, so always present as a browser.
 BROWSER_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-# Capture the full URL including the signed query string — preview.redd.it images
-# return 403 without their `?...&s=<sig>` signature.
-_GALLERY_IMG_RE = re.compile(r"""https://(?:preview|i)\.redd\.it/[^\s"'<>]+\.(?:jpg|jpeg|png|webp|gif)[^\s"'<>]*""")
+# Gallery images live in the post's gallery tiles. Selecting these classes scopes
+# extraction to the actual gallery, excluding comment images, the post thumbnail, and
+# "read next" suggestions that a whole-page scan would wrongly pull in.
+_GALLERY_TILE_SELECTOR = "a.gallery-item-thumbnail-link[href], img.gallery-tile-content[src]"
 
 
 def _headers() -> dict:
@@ -127,20 +128,20 @@ def _parse_thing(thing) -> dict | None:
     }
 
 
-async def _fetch_gallery_images(client: httpx.AsyncClient, post: dict) -> list[str] | None:
-    """Fetch a gallery post's page and extract its image URLs."""
-    permalink = post["url"].removeprefix("https://reddit.com")
-    try:
-        response = await _get_with_retry(client, f"{OLD_REDDIT}{permalink}", {}, label=f"gallery {post['reddit_id']}")
-    except Exception:
-        logger.warning("Failed to fetch gallery images for %s", post["reddit_id"])
-        return None
-    # preview.redd.it serves several variants per image: unsigned thumbnails (no `s=`,
-    # which 403) plus signed copies at different widths. Keep the largest signed variant.
+def _select_gallery_urls(page_html: str) -> list[str] | None:
+    """Pick the gallery's image URLs from a post page's HTML.
+
+    Each tile exposes the image at several widths via its link and thumbnail; preview.redd.it
+    needs its `s=` signature (unsigned variants 403), so keep the largest signed variant per image.
+    """
+    soup = BeautifulSoup(page_html, "html.parser")
     order: list[str] = []
     best: dict[str, tuple[int, str]] = {}
-    for match in _GALLERY_IMG_RE.findall(response.text):
-        url = html.unescape(match)
+    for el in soup.select(_GALLERY_TILE_SELECTOR):
+        raw = el.get("href") or el.get("src")
+        if not raw:
+            continue
+        url = html.unescape(raw)
         if "preview.redd.it" in url and not re.search(r"[?&]s=", url):
             continue
         path = url.split("?", 1)[0]
@@ -152,6 +153,17 @@ async def _fetch_gallery_images(client: httpx.AsyncClient, post: dict) -> list[s
         elif width > best[path][0]:
             best[path] = (width, url)
     return [best[path][1] for path in order][:20] or None
+
+
+async def _fetch_gallery_images(client: httpx.AsyncClient, post: dict) -> list[str] | None:
+    """Fetch a gallery post's page and extract its image URLs."""
+    permalink = post["url"].removeprefix("https://reddit.com")
+    try:
+        response = await _get_with_retry(client, f"{OLD_REDDIT}{permalink}", {}, label=f"gallery {post['reddit_id']}")
+    except Exception:
+        logger.warning("Failed to fetch gallery images for %s", post["reddit_id"])
+        return None
+    return _select_gallery_urls(response.text)
 
 
 async def fetch_top_posts(config: Config) -> list[dict]:

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -115,24 +115,32 @@ async def test_fetch_top_comments_text_only_has_no_media():
 
 
 @respx.mock
-async def test_fetch_gallery_images_picks_largest_signed_variant():
-    # Unsigned thumbnail (no s=) is skipped; the largest signed width wins even when a
-    # smaller signed variant appears first; &amp; decoded; i.redd.it kept without a signature.
+async def test_fetch_gallery_images_scopes_to_tiles_and_picks_largest_signed():
+    # Only the gallery tiles count: the largest signed width per image wins, unsigned variants
+    # are skipped, and images from comments / "read next" / thumbnail must NOT leak in.
     page_html = (
-        '<a href="https://preview.redd.it/aaa.jpg?width=108&amp;s=SIG_SMALL">small</a>'
-        '<a href="https://preview.redd.it/aaa.jpg?width=140&amp;auto=webp">unsigned thumb</a>'
-        '<a href="https://preview.redd.it/aaa.jpg?width=1170&amp;s=SIG_BIG">big</a>'
-        " text https://preview.redd.it/bbb.png?s=SIG3 more"
-        '<a href="https://i.redd.it/ccc.jpg">direct</a>'
+        '<div class="sitetable linklisting"><div class="thing">'
+        '<div class="media-preview-content">'
+        '<a class="gallery-item-thumbnail-link" href="https://preview.redd.it/aaa.jpg?width=1170&amp;s=BIG">'
+        '<img class="gallery-tile-content" src="https://preview.redd.it/aaa.jpg?width=108&amp;s=SMALL"/></a>'
+        '<a class="gallery-item-thumbnail-link" href="https://preview.redd.it/unsigned.jpg?width=140">'
+        '<img class="gallery-tile-content" src="https://preview.redd.it/bbb.jpg?width=960&amp;s=B"/></a>'
+        "</div></div></div>"
+        '<a class="thumbnail"><img src="https://preview.redd.it/THUMB.jpg?s=T"/></a>'
+        '<div class="commentarea"><div class="sitetable"><div class="comment"><div class="md">'
+        '<p><a href="https://preview.redd.it/COMMENT.jpg?s=CMT">&lt;image&gt;</a></p></div></div></div></div>'
     )
     respx.get(COMMENTS_URL).mock(return_value=Response(200, html=page_html))
     async with httpx.AsyncClient() as client:
         urls = await _fetch_gallery_images(client, SAMPLE_POST)
     assert urls == [
-        "https://preview.redd.it/aaa.jpg?width=1170&s=SIG_BIG",
-        "https://preview.redd.it/bbb.png?s=SIG3",
-        "https://i.redd.it/ccc.jpg",
+        "https://preview.redd.it/aaa.jpg?width=1170&s=BIG",
+        "https://preview.redd.it/bbb.jpg?width=960&s=B",
     ]
+    joined = " ".join(urls)
+    assert "COMMENT.jpg" not in joined
+    assert "THUMB.jpg" not in joined
+    assert "unsigned.jpg" not in joined
 
 
 @respx.mock


### PR DESCRIPTION
## Problem

Telegram gallery albums included images that aren't in the original Reddit gallery — e.g. photos posted in the **comments** appeared mixed in with the gallery.

Cause: `_fetch_gallery_images` ran its regex over the **entire post page**, so it also captured image-comment URLs, the post thumbnail, and "read next" suggested-post thumbnails. On one real post the gallery had 11 images but extraction returned 19.

## Fix

Scope extraction to the post's gallery tiles only — `a.gallery-item-thumbnail-link` / `img.gallery-tile-content` — instead of scanning the whole page. Comment images, the thumbnail, and "read next" thumbnails use different markup and are now excluded. The signed-URL + largest-width-per-image selection is preserved (extracted into `_select_gallery_urls`).

## Testing

- `ruff format --check` + `ruff check` clean; full suite **107 passed**. The gallery test now asserts comment/thumbnail/unsigned images are excluded.
- Verified live: the "moody cat ladies" gallery now returns exactly its 11 images (was 19), full-res, all download 200; a second gallery returns its 7 images cleanly.