### PR TITLE
Add 48h backlog fallback for publishing and purge stale unpublished posts

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -107,10 +107,10 @@ async def insert_post(post: dict) -> None:
         )
 
 
-async def get_unpublished_posts(limit: int | None = None) -> list[dict]:
+async def get_unpublished_posts(limit: int | None = None, max_age_hours: int = 24) -> list[dict]:
     query = (
         "SELECT * FROM posts WHERE published_to_tg = FALSE"
-        " AND created_utc > NOW() - INTERVAL '24 hours' ORDER BY score DESC"
+        f" AND created_utc > NOW() - INTERVAL '{int(max_age_hours)} hours' ORDER BY score DESC"
     )
     if limit:
         query += f" LIMIT {limit}"
@@ -139,6 +139,20 @@ async def mark_as_published(reddit_id: str, tg_message_id: int) -> None:
             tg_message_id,
             reddit_id,
         )
+
+
+async def delete_stale_posts(max_age_hours: int = 48) -> int:
+    """Delete unpublished posts older than max_age_hours to keep the DB from growing.
+
+    Published posts are kept (their reddit_id is needed for deduplication).
+    Returns the number of rows deleted.
+    """
+    async with _pool.acquire() as conn:
+        result = await conn.execute(
+            "DELETE FROM posts WHERE published_to_tg = FALSE"
+            f" AND created_utc <= NOW() - INTERVAL '{int(max_age_hours)} hours'"
+        )
+    return int(result.split()[-1]) if result else 0
 
 
 async def log_scrape(

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ import httpx
 from src.config import load_config
 from src.db import (
     close_db,
+    delete_stale_posts,
     get_unpublished_posts,
     init_db,
     insert_post,
@@ -38,6 +39,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 _VIDEO_DOMAINS = {"youtube.com", "youtu.be", "vimeo.com", "twitter.com", "x.com", "tiktok.com", "streamable.com"}
+
+# When no fresh (<24h) post is available, fall back to the unpublished backlog within this
+# window. Posts older than this are deleted on each scrape so the DB does not grow unbounded.
+_STALE_POST_AGE_HOURS = 48
 
 
 def _is_video_url(url: str) -> bool:
@@ -118,6 +123,9 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
     Returns True if published, False if skipped (publish failed), None if queue is empty.
     """
     posts = await get_unpublished_posts(limit=1)
+    if not posts:
+        # No fresh (<24h) post — fall back to the highest-scoring backlog post within the window.
+        posts = await get_unpublished_posts(limit=1, max_age_hours=_STALE_POST_AGE_HOURS)
     if not posts:
         return None
 
@@ -235,6 +243,9 @@ async def main() -> None:
         # Scrape if due
         if now - last_scrape >= config.scrape_interval:
             await scrape_new_posts(config)
+            deleted = await delete_stale_posts(_STALE_POST_AGE_HOURS)
+            if deleted:
+                logger.info("Deleted %d stale unpublished posts (>%dh)", deleted, _STALE_POST_AGE_HOURS)
             last_scrape = time.monotonic()
 
         # Publish one post (with timeout to prevent hanging on media download)

--- a/tests/test_db_extended.py
+++ b/tests/test_db_extended.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import src.db as db_module
 from src.db import (
+    delete_stale_posts,
     get_explanation,
     get_post,
     get_unpublished_posts,
@@ -58,6 +59,35 @@ async def test_get_unpublished_posts_24h_filter():
         await get_unpublished_posts()
     sql = conn.fetch.call_args.args[0]
     assert "24 hours" in sql
+
+
+async def test_get_unpublished_posts_custom_age_window():
+    pool, conn = _make_pool(fetch_return=[])
+    with patch.object(db_module, "_pool", pool):
+        await get_unpublished_posts(max_age_hours=48)
+    sql = conn.fetch.call_args.args[0]
+    assert "48 hours" in sql
+
+
+# --- delete_stale_posts ---
+
+
+async def test_delete_stale_posts_deletes_unpublished_older_than_window():
+    pool, conn = _make_pool(execute_return="DELETE 940")
+    with patch.object(db_module, "_pool", pool):
+        deleted = await delete_stale_posts(48)
+    sql = conn.execute.call_args.args[0]
+    assert "DELETE FROM posts" in sql
+    assert "published_to_tg = FALSE" in sql
+    assert "48 hours" in sql
+    assert deleted == 940
+
+
+async def test_delete_stale_posts_handles_zero():
+    pool, conn = _make_pool(execute_return="DELETE 0")
+    with patch.object(db_module, "_pool", pool):
+        deleted = await delete_stale_posts()
+    assert deleted == 0
 
 
 async def test_get_unpublished_posts_deserializes_media_urls():


### PR DESCRIPTION
## Проблема

Большие промежутки между публикациями возникают, когда пул свежих постов пустеет. `get_unpublished_posts` отбирает только посты `created_utc > NOW() - 24h`; в тихие часы по UTC скрейпы топа приносят 0–2 новых поста, и при паузе 15 мин (4 поста/час) выпускать становится нечего — бот простаивает целыми 15-минутными слотами. Параллельно копится бэклог неопубликованных постов старше 24ч (≈940), которые по этому фильтру не выйдут никогда.

## Изменения

- `get_unpublished_posts` принимает `max_age_hours` (по умолчанию 24 — поведение не меняется).
- В `publish_one` добавлен фолбэк: если свежих (<24ч) постов нет, берётся лучший по рейтингу пост из окна 48ч (`ORDER BY score DESC`).
- Новая `delete_stale_posts(max_age_hours=48)` удаляет неопубликованные посты старше 48ч и вызывается после каждого скрейпа. Опубликованные посты сохраняются — их `reddit_id` нужен для дедупликации, иначе вернувшийся в топ пост опубликовался бы повторно.

## Тесты

Добавлено покрытие на `max_age_hours` и `delete_stale_posts`. Все 110 тестов проходят, ruff чист.