### PR TITLE
Fix silently dropped posts and title-only text posts

### DIFF
--- a/src/publisher/telegram.py
+++ b/src/publisher/telegram.py
@@ -40,6 +40,45 @@ def _api_url(token: str, method: str) -> str:
     return TELEGRAM_API.format(token=token, method=method)
 
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _html_to_plain(text: str) -> str:
+    """Strip HTML tags and unescape entities so a message can be re-sent without parse_mode."""
+    return _html.unescape(_HTML_TAG_RE.sub("", text))
+
+
+def _is_parse_error(response: httpx.Response) -> bool:
+    return response.status_code == 400 and "can't parse entities" in response.text.lower()
+
+
+async def _post_message(
+    client: httpx.AsyncClient,
+    config: Config,
+    method: str,
+    data: dict,
+    *,
+    files: dict | None = None,
+    text_field: str = "caption",
+) -> tuple[int | None, httpx.Response]:
+    """POST to Telegram, retrying once as plain text if HTML parsing fails.
+
+    A single malformed tag used to make Telegram reject the whole message; the caller then
+    dropped the post permanently. Retrying without parse_mode preserves the post as plain text.
+    Returns (message_id | None, last_response) so callers can inspect other failures.
+    """
+    url = _api_url(config.telegram_bot_token, method)
+    response = await client.post(url, data=data, files=files)
+    if _is_parse_error(response) and text_field in data:
+        logger.info("%s hit an HTML parse error, retrying as plain text", method)
+        plain = {k: v for k, v in data.items() if k != "parse_mode"}
+        plain[text_field] = _html_to_plain(data[text_field])
+        response = await client.post(url, data=plain, files=files)
+    if response.status_code == 200:
+        return response.json()["result"]["message_id"], response
+    return None, response
+
+
 def _md_to_telegram_html(text: str) -> str:
     """Convert Reddit markdown subset to Telegram HTML."""
     # Remove Reddit markdown backslash escapes (e.g. \- \( \) \. \# etc.)
@@ -110,6 +149,37 @@ def _build_footer(post: dict, config: Config) -> str:
     return "\n\n".join(parts)
 
 
+def _take_raw_chunk(raw: str, budget: int) -> tuple[str, str]:
+    """Take a leading word-boundary slice of RAW markdown whose converted-HTML length
+    fits ``budget``. Returns ``(converted_html, remaining_raw)``.
+
+    Splitting the raw text (rather than the already-converted HTML) keeps every chunk
+    independently valid HTML — a markdown token straddling the boundary degrades to plain
+    text instead of leaving a dangling ``<a>``/``<b>`` tag that Telegram would reject.
+    """
+    whole = _md_to_telegram_html(raw)
+    if len(whole) <= budget:
+        return whole, ""
+
+    # Binary-search the largest word-boundary raw prefix whose conversion fits the budget.
+    lo, hi, best = 0, len(raw), 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        cut = raw.rfind(" ", 0, mid)
+        if cut <= 0:
+            cut = mid
+        if cut and len(_md_to_telegram_html(raw[:cut])) <= budget:
+            best = cut
+            lo = mid + 1
+        else:
+            hi = mid - 1
+
+    if best <= 0:
+        # A single unbroken token (e.g. a long URL) exceeds the budget — hard-cut it.
+        best = min(budget, len(raw))
+    return _md_to_telegram_html(raw[:best]), raw[best:].lstrip()
+
+
 def _build_media_texts(post: dict, config: Config) -> tuple[str, list[str]]:
     """Build (caption, overflow_messages) for media posts.
 
@@ -133,31 +203,14 @@ def _build_media_texts(post: dict, config: Config) -> tuple[str, list[str]]:
         return full, []
 
     # Caption budget is smaller (MAX_CAPTION_LEN) than overflow messages (MAX_MESSAGE_LEN).
-    caption_budget = MAX_CAPTION_LEN - len(title_block)
+    # Reserve room for the trailing "..." continuation marker.
+    caption_budget = MAX_CAPTION_LEN - len(title_block) - len("...")
     if caption_budget <= 0:
-        return title_html[:MAX_CAPTION_LEN], _chunk_text_evenly(selftext_html, footer)
+        # Title alone fills the caption — escape+wrap the raw title so <b> stays balanced.
+        safe_title = _html.escape(post["title"])[: MAX_CAPTION_LEN - len("<b></b>")]
+        return f"<b>{safe_title}</b>", _chunk_text_evenly(selftext, footer)
 
-    # Figure out minimum number of messages (1 caption + N overflow) and split evenly.
-    total_text = len(selftext_html) + len(footer_block)
-    n_overflow = math.ceil((total_text - caption_budget) / MAX_MESSAGE_LEN) if total_text > caption_budget else 0
-    n_total = 1 + n_overflow
-
-    # Target size per message — selftext portion only (title/footer handled separately)
-    target = math.ceil(len(selftext_html) / n_total)
-    # Caption portion must not exceed budget
-    caption_target = min(target, caption_budget)
-
-    # Split selftext at word boundary near caption_target
-    if len(selftext_html) <= caption_target:
-        caption_text = selftext_html
-        remaining = ""
-    else:
-        split = selftext_html.rfind(" ", 0, caption_target)
-        if split == -1:
-            split = caption_target
-        caption_text = selftext_html[:split]
-        remaining = selftext_html[split:].lstrip()
-
+    caption_text, remaining = _take_raw_chunk(selftext, caption_budget)
     caption = f"{title_block}{caption_text}"
 
     if not remaining:
@@ -172,29 +225,31 @@ def _build_media_texts(post: dict, config: Config) -> tuple[str, list[str]]:
 
 
 def _chunk_text_evenly(body: str, footer: str) -> list[str]:
-    """Split body into evenly-sized chunks with footer appended to the last."""
+    """Split RAW body into evenly-sized chunks with footer appended to the last.
+
+    Each chunk is converted to HTML independently so tags are never split across messages.
+    """
     footer_block = f"\n\n{footer}"
-    total = body + footer_block
-    if len(total) <= MAX_MESSAGE_LEN:
-        return [f"\U0000261d\n...{total}"]
+    marker = "\U0000261d\n..."
+    whole_html = _md_to_telegram_html(body)
+    if len(f"{marker}{whole_html}{footer_block}") <= MAX_MESSAGE_LEN:
+        return [f"{marker}{whole_html}{footer_block}"]
 
-    # How many chunks do we need?
-    n = math.ceil((len(body) + len(footer_block)) / MAX_MESSAGE_LEN)
+    # Aim for even-sized messages: estimate the chunk count from the converted length,
+    # then greedily fill each chunk up to that target by splitting the raw text.
+    overhead = len(marker) + len("...")
+    n = math.ceil((len(whole_html) + len(footer_block)) / (MAX_MESSAGE_LEN - overhead))
+    target = math.ceil(len(whole_html) / max(n, 1))
 
-    chunks = []
+    chunks: list[str] = []
     remaining = body
-    for i in range(n):
-        chunks_left = n - i
-        is_last = chunks_left == 1
-        if is_last:
-            chunks.append(f"\U0000261d\n...{remaining}{footer_block}")
+    while remaining:
+        rem_html = _md_to_telegram_html(remaining)
+        if len(f"{marker}{rem_html}{footer_block}") <= MAX_MESSAGE_LEN:
+            chunks.append(f"{marker}{rem_html}{footer_block}")
             break
-        target = math.ceil(len(remaining) / chunks_left)
-        split = remaining.rfind(" ", 0, target)
-        if split == -1:
-            split = target
-        chunks.append(f"\U0000261d\n...{remaining[:split]}...")
-        remaining = remaining[split:].lstrip()
+        chunk_html, remaining = _take_raw_chunk(remaining, target)
+        chunks.append(f"{marker}{chunk_html}...")
 
     return chunks
 
@@ -211,22 +266,14 @@ async def _send_photo(
     }
     if reply_markup:
         data["reply_markup"] = reply_markup
-    response = await client.post(
-        _api_url(config.telegram_bot_token, "sendPhoto"),
-        data=data,
-        files={"photo": photo_bytes},
-    )
-    if response.status_code == 200:
-        return response.json()["result"]["message_id"]
+    msg_id, response = await _post_message(client, config, "sendPhoto", data, files={"photo": photo_bytes})
+    if msg_id is not None:
+        return msg_id
     if "PHOTO_INVALID_DIMENSIONS" in response.text:
         resized = _fit_photo_for_telegram(photo_bytes)
-        response = await client.post(
-            _api_url(config.telegram_bot_token, "sendPhoto"),
-            data=data,
-            files={"photo": resized},
-        )
-        if response.status_code == 200:
-            return response.json()["result"]["message_id"]
+        msg_id, response = await _post_message(client, config, "sendPhoto", data, files={"photo": resized})
+        if msg_id is not None:
+            return msg_id
     logger.warning("sendPhoto failed: %s", response.text)
     return None
 
@@ -243,12 +290,9 @@ async def _send_photo_url(
     }
     if reply_markup:
         data["reply_markup"] = reply_markup
-    response = await client.post(
-        _api_url(config.telegram_bot_token, "sendPhoto"),
-        data=data,
-    )
-    if response.status_code == 200:
-        return response.json()["result"]["message_id"]
+    msg_id, response = await _post_message(client, config, "sendPhoto", data)
+    if msg_id is not None:
+        return msg_id
     logger.warning("sendPhoto (url) failed: %s", response.text)
     return None
 
@@ -265,13 +309,15 @@ async def _send_video(
     }
     if reply_markup:
         data["reply_markup"] = reply_markup
-    response = await client.post(
-        _api_url(config.telegram_bot_token, "sendVideo"),
-        data=data,
+    msg_id, response = await _post_message(
+        client,
+        config,
+        "sendVideo",
+        data,
         files={"video": video_path.read_bytes()},  # noqa: ASYNC240
     )
-    if response.status_code == 200:
-        return response.json()["result"]["message_id"]
+    if msg_id is not None:
+        return msg_id
     logger.warning("sendVideo failed: %s", response.text)
     return None
 
@@ -287,13 +333,15 @@ async def _send_animation(
     }
     if reply_markup:
         data["reply_markup"] = reply_markup
-    response = await client.post(
-        _api_url(config.telegram_bot_token, "sendAnimation"),
-        data=data,
+    msg_id, response = await _post_message(
+        client,
+        config,
+        "sendAnimation",
+        data,
         files={"animation": (anim_path.name, anim_path.read_bytes(), "video/mp4")},  # noqa: ASYNC240
     )
-    if response.status_code == 200:
-        return response.json()["result"]["message_id"]
+    if msg_id is not None:
+        return msg_id
     logger.warning("sendAnimation failed: %s", response.text)
     return None
 
@@ -316,12 +364,9 @@ async def _send_message(
         data["reply_markup"] = reply_markup
     if reply_to:
         data["reply_to_message_id"] = reply_to
-    response = await client.post(
-        _api_url(config.telegram_bot_token, "sendMessage"),
-        data=data,
-    )
-    if response.status_code == 200:
-        return response.json()["result"]["message_id"]
+    msg_id, response = await _post_message(client, config, "sendMessage", data, text_field="text")
+    if msg_id is not None:
+        return msg_id
     logger.warning("sendMessage failed: %s", response.text)
     return None
 
@@ -353,6 +398,12 @@ async def _send_media_group(
             retry_after = response.json().get("parameters", {}).get("retry_after", 5)
             logger.info("sendMediaGroup rate-limited, sleeping %ds (attempt %d)", retry_after, attempt + 1)
             await asyncio.sleep(retry_after + 1)
+            continue
+        if _is_parse_error(response) and caption:
+            # parse_mode lives inside the media JSON — strip it and retry the caption as plain text.
+            logger.info("sendMediaGroup hit an HTML parse error, retrying as plain text")
+            media[0]["caption"] = _html_to_plain(caption)
+            media[0].pop("parse_mode", None)
             continue
         break
     logger.warning("sendMediaGroup failed: %s", response.text)
@@ -610,17 +661,18 @@ async def publish_comment(
         # Fallback to text if no media or media send failed
         if not msg_id:
             text = _format_comment(comment) if media_url else caption
-            response = await client.post(
-                _api_url(config.telegram_bot_token, "sendMessage"),
-                data={
+            msg_id, _ = await _post_message(
+                client,
+                config,
+                "sendMessage",
+                {
                     "chat_id": discussion_chat_id,
                     "text": text[:MAX_MESSAGE_LEN],
                     "parse_mode": "HTML",
                     "reply_to_message_id": reply_to_message_id,
                     "disable_web_page_preview": "true",
                 },
+                text_field="text",
             )
-            if response.status_code == 200:
-                msg_id = response.json()["result"]["message_id"]
 
     return msg_id

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -166,6 +166,37 @@ async def _fetch_gallery_images(client: httpx.AsyncClient, post: dict) -> list[s
     return _select_gallery_urls(response.text)
 
 
+def _select_selftext(page_html: str, reddit_id: str) -> str | None:
+    """Extract a self-post's body from its own page, scoped to the post's ``thing``.
+
+    Scoping by ``data-fullname`` avoids pulling in comment bodies, which share the
+    ``div.usertext-body div.md`` markup.
+    """
+    soup = BeautifulSoup(page_html, "html.parser")
+    thing = soup.select_one(f"div.thing[data-fullname='{reddit_id}']")
+    if not thing:
+        return None
+    md = thing.select_one("div.expando div.usertext-body div.md") or thing.select_one("div.usertext-body div.md")
+    if not md:
+        return None
+    return md.get_text("\n", strip=True) or None
+
+
+async def _fetch_selftext(client: httpx.AsyncClient, post: dict) -> str | None:
+    """Fetch a text post's page to recover a body the listing HTML omitted.
+
+    old.reddit's listing does not always inline the full self-text (long posts load it on
+    expand), so a title-only text post is refetched from its own page.
+    """
+    permalink = post["url"].removeprefix("https://reddit.com")
+    try:
+        response = await _get_with_retry(client, f"{OLD_REDDIT}{permalink}", {}, label=f"selftext {post['reddit_id']}")
+    except Exception:
+        logger.warning("Failed to fetch selftext for %s", post["reddit_id"])
+        return None
+    return _select_selftext(response.text, post["reddit_id"])
+
+
 async def fetch_top_posts(config: Config) -> list[dict]:
     url = f"{OLD_REDDIT}/top/"
     params = {"t": "day", "limit": config.posts_limit}
@@ -180,6 +211,10 @@ async def fetch_top_posts(config: Config) -> list[dict]:
                 # Space out per-post page fetches so old.reddit doesn't rate-limit the burst.
                 await asyncio.sleep(2)
                 post["media_urls"] = await _fetch_gallery_images(client, post)
+            elif post["post_type"] == "text" and not post["selftext"]:
+                # Listing omitted the body — refetch the post page so it doesn't publish title-only.
+                await asyncio.sleep(2)
+                post["selftext"] = await _fetch_selftext(client, post)
 
     logger.info("Fetched %d posts from Reddit", len(posts))
     return posts

--- a/tests/test_publisher_extended.py
+++ b/tests/test_publisher_extended.py
@@ -1,13 +1,32 @@
+import re
+
+import httpx
 import respx
 from httpx import Response
 
 from src.config import Config
 from src.publisher.telegram import (
+    MAX_CAPTION_LEN,
+    MAX_MESSAGE_LEN,
     _build_footer,
+    _build_media_texts,
     _chunk_text_evenly,
+    _html_to_plain,
     _md_to_telegram_html,
     _publish_text_messages,
+    _send_message,
+    _take_raw_chunk,
+    publish_post,
 )
+
+
+def _tags_balanced(s: str) -> bool:
+    """No HTML tag is split across the message boundary."""
+    opens = len(re.findall(r"<(?:b|i|s|code|a)(?:\s|>)", s))
+    closes = len(re.findall(r"</(?:b|i|s|code|a)>", s))
+    dangling = re.search(r"<[^>]*$", s) is not None
+    return opens == closes and not dangling
+
 
 CONFIG = Config(
     telegram_bot_token="testtoken",
@@ -153,6 +172,118 @@ def test_chunk_evenly_middle_chunks_have_prefix():
         assert "\U0001f4ac" in chunk or "..." in chunk
 
 
+# --- _take_raw_chunk (raw splitting keeps HTML valid) ---
+
+
+def test_take_raw_chunk_whole_fits():
+    html, rest = _take_raw_chunk("hello world", 1000)
+    assert html == "hello world"
+    assert rest == ""
+
+
+def test_take_raw_chunk_respects_budget():
+    html, rest = _take_raw_chunk("word " * 500, 100)
+    assert len(html) <= 100
+    assert rest  # there is leftover
+
+
+def test_take_raw_chunk_never_splits_a_link_tag():
+    # A markdown link straddling the budget must not leave a dangling <a ...> in the chunk.
+    raw = "x" * 90 + " [click here](https://example.com/some/long/path) " + "tail " * 50
+    html, rest = _take_raw_chunk(raw, 100)
+    assert _tags_balanced(html)
+    assert "<a" not in html or "</a>" in html
+
+
+def test_take_raw_chunk_hard_cuts_oversized_token():
+    # A single token longer than the budget still makes progress (no infinite loop).
+    html, rest = _take_raw_chunk("a" * 500, 100)
+    assert html
+    assert len(rest) < 500
+
+
+# --- _build_media_texts: HTML stays valid across the split ---
+
+
+def test_media_caption_and_overflow_keep_tags_balanced():
+    body = "x" * 930 + " [label](https://example.com/" + "a" * 200 + ") " + "tail " * 400
+    post = {**BASE_POST, "post_type": "image", "content_url": "https://i.redd.it/a.jpg", "selftext": body}
+    caption, overflow = _build_media_texts(post, CONFIG)
+    assert len(caption) <= MAX_CAPTION_LEN
+    assert _tags_balanced(caption)
+    for msg in overflow:
+        assert len(msg) <= MAX_MESSAGE_LEN
+        assert _tags_balanced(msg)
+
+
+def test_media_caption_link_pushed_whole_into_overflow_not_broken():
+    body = "x" * 990 + " [label](https://example.com/link) " + "tail " * 400
+    post = {**BASE_POST, "post_type": "image", "content_url": "https://i.redd.it/a.jpg", "selftext": body}
+    caption, overflow = _build_media_texts(post, CONFIG)
+    joined = caption + " ".join(overflow)
+    # The link survives intact somewhere rather than being cut in half.
+    assert '<a href="https://example.com/link">label</a>' in joined
+
+
+def test_chunk_text_evenly_keeps_tags_balanced_when_link_straddles():
+    body = "y" * 3000 + " [label](https://example.com/x) " + "z" * 3000
+    chunks = _chunk_text_evenly(body, "footer")
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert len(chunk) <= MAX_MESSAGE_LEN
+        assert _tags_balanced(chunk)
+
+
+# --- _html_to_plain / plain-text fallback (Fix B) ---
+
+
+def test_html_to_plain_strips_tags_and_unescapes():
+    assert _html_to_plain('<b>Hi</b> <a href="u">x</a> a &amp; b &lt;c&gt;') == "Hi x a & b <c>"
+
+
+@respx.mock
+async def test_send_message_retries_as_plain_text_on_parse_error():
+    responses = [
+        Response(400, json={"description": "Bad Request: can't parse entities: unclosed tag"}),
+        Response(200, json={"result": {"message_id": 77}}),
+    ]
+    sent = []
+
+    def handler(request):
+        sent.append(request.content.decode())
+        return responses[len(sent) - 1]
+
+    respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(side_effect=handler)
+    async with httpx.AsyncClient() as client:
+        msg_id = await _send_message(client, CONFIG, "<b>broken")
+    assert msg_id == 77
+    assert len(sent) == 2
+    # Retry dropped parse_mode and stripped the tag.
+    assert "parse_mode" not in sent[1]
+
+
+@respx.mock
+async def test_media_post_not_dropped_on_caption_parse_error():
+    # sendPhoto rejects the HTML caption once, then the plain-text retry succeeds — the post
+    # must reach Telegram instead of being silently dropped.
+    responses = [
+        Response(400, json={"description": "Bad Request: can't parse entities: unclosed tag"}),
+        Response(200, json={"result": {"message_id": 55}}),
+    ]
+    calls = {"n": 0}
+
+    def handler(request):
+        r = responses[calls["n"]]
+        calls["n"] += 1
+        return r
+
+    respx.post("https://api.telegram.org/bottesttoken/sendPhoto").mock(side_effect=handler)
+    post = {**BASE_POST, "post_type": "link", "content_url": None, "preview_url": "https://img/x.jpg"}
+    msg_id = await publish_post(CONFIG, post)
+    assert msg_id == 55
+    assert calls["n"] == 2
+
+
 # --- _publish_text_messages ---
 
 
@@ -162,7 +293,6 @@ async def test_publish_text_single_message():
         return_value=Response(200, json={"result": {"message_id": 1}})
     )
     post = {**BASE_POST, "selftext": "Short text."}
-    import httpx
 
     async with httpx.AsyncClient() as client:
         msg_id = await _publish_text_messages(client, CONFIG, post)
@@ -180,7 +310,6 @@ async def test_publish_text_split_adds_continuation_marker():
     respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(side_effect=capture)
     # 900 words × 5 chars = 4500 chars → exceeds MAX_MESSAGE_LEN (4096) → forces split
     post = {**BASE_POST, "selftext": "word " * 900}
-    import httpx
 
     async with httpx.AsyncClient() as client:
         await _publish_text_messages(client, CONFIG, post)
@@ -198,7 +327,6 @@ async def test_publish_text_first_message_ends_with_ellipsis_when_split():
 
     respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(side_effect=capture)
     post = {**BASE_POST, "selftext": "word " * 900}
-    import httpx
 
     async with httpx.AsyncClient() as client:
         await _publish_text_messages(client, CONFIG, post)

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -7,6 +7,8 @@ from httpx import Response
 from src.config import Config
 from src.scraper.reddit import (
     _fetch_gallery_images,
+    _fetch_selftext,
+    _select_selftext,
     fetch_fresh_hls_url,
     fetch_top_comments,
     fetch_top_posts,
@@ -148,6 +150,82 @@ async def test_fetch_gallery_images_none_on_error():
     respx.get(COMMENTS_URL).mock(return_value=Response(500))
     async with httpx.AsyncClient() as client:
         assert await _fetch_gallery_images(client, SAMPLE_POST) is None
+
+
+# --- _select_selftext / _fetch_selftext ---
+
+POST_PAGE_HTML = (
+    '<div class="content">'
+    '<div class="sitetable"><div class="thing id-t3_txt self" data-fullname="t3_txt">'
+    '<div class="entry"><div class="expando"><div class="usertext-body"><div class="md">'
+    "<p>Recovered body line one.</p><p>Line two.</p>"
+    "</div></div></div></div></div></div>"
+    '<div class="commentarea"><div class="sitetable"><div class="comment" data-fullname="t1_c1">'
+    '<div class="usertext-body"><div class="md"><p>a comment body must be ignored</p></div></div>'
+    "</div></div></div>"
+    "</div>"
+)
+
+
+def test_select_selftext_scoped_to_post_thing():
+    body = _select_selftext(POST_PAGE_HTML, "t3_txt")
+    assert body == "Recovered body line one.\nLine two."
+
+
+def test_select_selftext_ignores_comment_bodies():
+    body = _select_selftext(POST_PAGE_HTML, "t3_txt")
+    assert "comment body" not in (body or "")
+
+
+def test_select_selftext_none_when_thing_absent():
+    assert _select_selftext(POST_PAGE_HTML, "t3_missing") is None
+
+
+@respx.mock
+async def test_fetch_selftext_returns_body():
+    post = {"reddit_id": "t3_txt", "url": "https://reddit.com/r/x/comments/txt/t/"}
+    respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(200, html=POST_PAGE_HTML))
+    async with httpx.AsyncClient() as client:
+        assert await _fetch_selftext(client, post) == "Recovered body line one.\nLine two."
+
+
+@respx.mock
+async def test_fetch_selftext_none_on_error():
+    post = {"reddit_id": "t3_txt", "url": "https://reddit.com/r/x/comments/txt/t/"}
+    respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(500))
+    async with httpx.AsyncClient() as client:
+        assert await _fetch_selftext(client, post) is None
+
+
+@respx.mock
+async def test_fetch_top_posts_recovers_missing_selftext_from_post_page():
+    # A self post whose listing HTML carries no body — the scraper must refetch the post page.
+    listing = (
+        '<div class="thing id-t3_txt self" data-fullname="t3_txt" data-author="carol"'
+        ' data-subreddit="AskReddit" data-url="https://www.reddit.com/r/AskReddit/comments/txt/q/"'
+        ' data-domain="self.AskReddit" data-permalink="/r/AskReddit/comments/txt/q/"'
+        ' data-score="10" data-comments-count="1" data-timestamp="1700000000000">'
+        '<p class="title"><a class="title" href="#">Just a title</a></p>'
+        "</div>"
+    )
+    respx.get("https://old.reddit.com/top/").mock(return_value=Response(200, html=listing))
+    respx.get("https://old.reddit.com/r/AskReddit/comments/txt/q/").mock(
+        return_value=Response(200, html=POST_PAGE_HTML)
+    )
+    posts = await fetch_top_posts(CONFIG)
+    txt = next(p for p in posts if p["reddit_id"] == "t3_txt")
+    assert txt["selftext"] == "Recovered body line one.\nLine two."
+
+
+@respx.mock
+async def test_fetch_top_posts_keeps_listing_selftext_without_refetch():
+    # When the listing already has the body, no post-page request should be needed.
+    route = respx.get("https://old.reddit.com/r/AskReddit/comments/text1/q/").mock(return_value=Response(500))
+    respx.get("https://old.reddit.com/top/").mock(return_value=Response(200, html=LISTING_HTML))
+    posts = await fetch_top_posts(CONFIG)
+    txt = next(p for p in posts if p["reddit_id"] == "t3_text1")
+    assert txt["selftext"] == "This is the body of the text post."
+    assert not route.called
 
 
 # --- fetch_fresh_hls_url ---


### PR DESCRIPTION
## Проблема

Пользователь заметил, что часть постов не доходит до Telegram, а часть публикуется без текста. Разбор выявил три причины.

## Fix A — посты терялись из-за рваного HTML в подписях к медиа

`_build_media_texts` и `_chunk_text_evenly` резали **уже сконвертированный** HTML по границе слова, из-за чего граница попадала внутрь тега (`<a href="...">`, `<b>`). Получался незакрытый тег → Telegram отвечает `400 can't parse entities` → отправка медиа падает → пост помечается опубликованным (`published=0`) и навсегда пропадает.

Теперь режется **сырой** markdown, каждый кусок конвертируется отдельно (как уже делал текстовый путь). Новый `_take_raw_chunk` берёт максимальный кусок по границе слова в рамках бюджета; сверхдлинный токен (URL) режется жёстко без зацикливания.

## Fix B — тихая потеря поста при любой ошибке HTML

Все отправители при не-200 просто возвращали `None`, без повтора. Новый хелпер `_post_message` при `400 can't parse entities` **повторяет отправку без `parse_mode`**, конвертируя текст в plain (`_html_to_plain`). Подключён к `sendMessage`, `sendPhoto`/`sendPhoto(url)`, `sendVideo`, `sendAnimation`, `sendMediaGroup` и текстовому фолбэку комментариев.

## Fix C — публикация без текста

`selftext` извлекался только из листинга `/top/`, а old.reddit не всегда встраивает тело self-поста в листинг → часть текстовых постов уходила только с заголовком. Теперь для текстовых постов с пустым `selftext` дозапрашивается страница поста (`_fetch_selftext` / `_select_selftext`, привязка к `data-fullname`, чтобы не подхватить комментарии).

## Тесты

- Полный набор: **127 passed**, ruff чистый.
- Добавлены тесты: raw-splitting сохраняет валидный HTML, ссылка целиком уходит в overflow, plain-text фолбэк доставляет пост при parse-ошибке, дозапрос тела текстового поста со страницы.

## Оговорки

- Fix A и B воспроизведены до правки и проверены после.
- Fix C — вывод из кода: эмпирически не проверен, т.к. old.reddit отдаёт 403 на этот IP. Фикс безопасен — дозапрос идёт только при пустом `selftext`.