### PR TITLE
Fix dropped/title-only posts and tiny link previews

### DIFF
--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -197,6 +197,35 @@ async def _fetch_selftext(client: httpx.AsyncClient, post: dict) -> str | None:
     return _select_selftext(response.text, post["reddit_id"])
 
 
+def _select_preview_image(page_html: str) -> str | None:
+    """Pick a link post's large preview image from its page's ``og:image`` meta tag.
+
+    The listing only exposes a ~140px ``thumbs.redditmedia.com`` thumbnail, which Telegram
+    renders tiny. The post page's ``og:image`` is the full ``external-preview.redd.it`` render
+    (the same large image Reddit shows), so prefer it. The default Reddit snoo/icon served for
+    previewless posts lives on ``redditstatic.com`` and is rejected.
+    """
+    soup = BeautifulSoup(page_html, "html.parser")
+    meta = soup.select_one('meta[property="og:image"]')
+    if not meta:
+        return None
+    url = html.unescape((meta.get("content") or "").strip())
+    if not url.startswith("http") or "redditstatic.com" in url:
+        return None
+    return url
+
+
+async def _fetch_preview_image(client: httpx.AsyncClient, post: dict) -> str | None:
+    """Fetch a link post's page to recover the large preview the listing thumbnail shrinks."""
+    permalink = post["url"].removeprefix("https://reddit.com")
+    try:
+        response = await _get_with_retry(client, f"{OLD_REDDIT}{permalink}", {}, label=f"preview {post['reddit_id']}")
+    except Exception:
+        logger.warning("Failed to fetch preview image for %s", post["reddit_id"])
+        return None
+    return _select_preview_image(response.text)
+
+
 async def fetch_top_posts(config: Config) -> list[dict]:
     url = f"{OLD_REDDIT}/top/"
     params = {"t": "day", "limit": config.posts_limit}
@@ -215,6 +244,12 @@ async def fetch_top_posts(config: Config) -> list[dict]:
                 # Listing omitted the body — refetch the post page so it doesn't publish title-only.
                 await asyncio.sleep(2)
                 post["selftext"] = await _fetch_selftext(client, post)
+            elif post["post_type"] == "link" and post["preview_url"]:
+                # Listing only has a tiny thumbnail — refetch for the full-size og:image preview.
+                await asyncio.sleep(2)
+                bigger = await _fetch_preview_image(client, post)
+                if bigger:
+                    post["preview_url"] = bigger
 
     logger.info("Fetched %d posts from Reddit", len(posts))
     return posts

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -7,7 +7,9 @@ from httpx import Response
 from src.config import Config
 from src.scraper.reddit import (
     _fetch_gallery_images,
+    _fetch_preview_image,
     _fetch_selftext,
+    _select_preview_image,
     _select_selftext,
     fetch_fresh_hls_url,
     fetch_top_comments,
@@ -226,6 +228,87 @@ async def test_fetch_top_posts_keeps_listing_selftext_without_refetch():
     txt = next(p for p in posts if p["reddit_id"] == "t3_text1")
     assert txt["selftext"] == "This is the body of the text post."
     assert not route.called
+
+
+# --- _select_preview_image / _fetch_preview_image ---
+
+PREVIEW_PAGE_HTML = (
+    "<html><head>"
+    '<meta property="og:image" content="https://external-preview.redd.it/big.jpg?width=1080&amp;s=SIG"/>'
+    "</head><body></body></html>"
+)
+
+
+def test_select_preview_image_reads_og_image():
+    assert _select_preview_image(PREVIEW_PAGE_HTML) == "https://external-preview.redd.it/big.jpg?width=1080&s=SIG"
+
+
+def test_select_preview_image_rejects_default_reddit_icon():
+    html_icon = '<meta property="og:image" content="https://www.redditstatic.com/icon.png"/>'
+    assert _select_preview_image(html_icon) is None
+
+
+def test_select_preview_image_none_when_absent():
+    assert _select_preview_image("<html><head></head></html>") is None
+
+
+@respx.mock
+async def test_fetch_preview_image_returns_url():
+    post = {"reddit_id": "t3_lnk", "url": "https://reddit.com/r/x/comments/lnk/l/"}
+    respx.get("https://old.reddit.com/r/x/comments/lnk/l/").mock(return_value=Response(200, html=PREVIEW_PAGE_HTML))
+    async with httpx.AsyncClient() as client:
+        assert await _fetch_preview_image(client, post) == "https://external-preview.redd.it/big.jpg?width=1080&s=SIG"
+
+
+@respx.mock
+async def test_fetch_preview_image_none_on_error():
+    post = {"reddit_id": "t3_lnk", "url": "https://reddit.com/r/x/comments/lnk/l/"}
+    respx.get("https://old.reddit.com/r/x/comments/lnk/l/").mock(return_value=Response(500))
+    async with httpx.AsyncClient() as client:
+        assert await _fetch_preview_image(client, post) is None
+
+
+@respx.mock
+async def test_fetch_top_posts_upgrades_link_thumbnail_to_og_image():
+    # A link post whose listing carries only a tiny thumbnail — the scraper must refetch the
+    # post page and replace preview_url with the full-size og:image.
+    listing = (
+        '<div class="thing id-t3_lnk link" data-fullname="t3_lnk" data-author="erin"'
+        ' data-subreddit="news" data-url="https://example.com/article" data-domain="example.com"'
+        ' data-permalink="/r/news/comments/lnk/headline/"'
+        ' data-score="321" data-comments-count="89" data-timestamp="1700000000000">'
+        '<a class="thumbnail" href="#"><img src="//b.thumbs.redditmedia.com/tiny.jpg"></a>'
+        '<a class="title" href="#">An external article</a>'
+        "</div>"
+    )
+    respx.get("https://old.reddit.com/top/").mock(return_value=Response(200, html=listing))
+    respx.get("https://old.reddit.com/r/news/comments/lnk/headline/").mock(
+        return_value=Response(200, html=PREVIEW_PAGE_HTML)
+    )
+    posts = await fetch_top_posts(CONFIG)
+    lnk = next(p for p in posts if p["reddit_id"] == "t3_lnk")
+    assert lnk["preview_url"] == "https://external-preview.redd.it/big.jpg?width=1080&s=SIG"
+
+
+@respx.mock
+async def test_fetch_top_posts_keeps_thumbnail_when_og_image_missing():
+    # If the post page has no usable og:image, keep the listing thumbnail as a fallback.
+    listing = (
+        '<div class="thing id-t3_lnk link" data-fullname="t3_lnk" data-author="erin"'
+        ' data-subreddit="news" data-url="https://example.com/article" data-domain="example.com"'
+        ' data-permalink="/r/news/comments/lnk/headline/"'
+        ' data-score="321" data-comments-count="89" data-timestamp="1700000000000">'
+        '<a class="thumbnail" href="#"><img src="//b.thumbs.redditmedia.com/tiny.jpg"></a>'
+        '<a class="title" href="#">An external article</a>'
+        "</div>"
+    )
+    respx.get("https://old.reddit.com/top/").mock(return_value=Response(200, html=listing))
+    respx.get("https://old.reddit.com/r/news/comments/lnk/headline/").mock(
+        return_value=Response(200, html="<html><head></head></html>")
+    )
+    posts = await fetch_top_posts(CONFIG)
+    lnk = next(p for p in posts if p["reddit_id"] == "t3_lnk")
+    assert lnk["preview_url"] == "https://b.thumbs.redditmedia.com/tiny.jpg"
 
 
 # --- fetch_fresh_hls_url ---


### PR DESCRIPTION
## Summary

- **Large link previews.** External-link posts published only the ~140px old.reddit listing thumbnail, so Telegram rendered a tiny image. The scraper now refetches the post page and uses its `og:image` (the full-size `external-preview.redd.it` render), falling back to the thumbnail when no usable og:image exists.
- **Title-only text posts.** Self-posts whose listing HTML omitted the body are refetched from their own page so they no longer publish as title-only.
- **Silently dropped posts.** Fixed posts being lost during publishing, plus a 48h backlog fallback and purge of stale unpublished posts.

## Notes

The link-preview refetch reuses the existing post-page fetch pattern (retry/backoff + 2s spacing) already used for text and gallery posts, and is gated on the listing actually having a thumbnail.

## Testing

`uv run pytest` — 134 passed.