### PR TITLE
Retry Telegram sends on 429 and send link-only notice for failed posts

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ from src.db import (
     mark_as_published,
 )
 from src.publisher.poller import UpdatePoller
-from src.publisher.telegram import publish_comment, publish_post
+from src.publisher.telegram import publish_comment, publish_failed_notice, publish_post
 from src.scraper.media import (
     cleanup,
     compress_video,
@@ -117,6 +117,18 @@ async def _publish_comments_delayed(config, poller: "UpdatePoller", post: dict, 
         logger.warning("Failed to publish comments for %s", post["reddit_id"], exc_info=True)
 
 
+async def _drop_with_notice(config, post: dict, reason: str) -> bool:
+    """Mark a post handled but send a link-only notice so it isn't silently lost."""
+    logger.warning("%s %s — sending link-only fallback", reason, post["reddit_id"])
+    try:
+        fallback_id = await publish_failed_notice(config, post)
+    except Exception as e:
+        logger.warning("Link-only fallback failed for %s: %s", post["reddit_id"], e)
+        fallback_id = None
+    await mark_as_published(post["reddit_id"], fallback_id or 0)
+    return False
+
+
 async def publish_one(config, poller: "UpdatePoller") -> bool | None:
     """Pick the next unpublished post and publish it.
 
@@ -136,15 +148,11 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
     if post["post_type"] == "image" and post.get("content_url"):
         media_path = await download_image(post["content_url"])
         if media_path is None:
-            logger.warning("Skipping image post %s: failed to download", post["reddit_id"])
-            await mark_as_published(post["reddit_id"], 0)
-            return False
+            return await _drop_with_notice(config, post, "Image download failed for")
     elif post["post_type"] == "gif" and post.get("content_url"):
         media_path = await download_gif(post["content_url"])
         if media_path is None:
-            logger.warning("Skipping gif post %s: failed to download", post["reddit_id"])
-            await mark_as_published(post["reddit_id"], 0)
-            return False
+            return await _drop_with_notice(config, post, "GIF download failed for")
     elif post["post_type"] == "video" and post.get("video_url"):
         fresh_hls = await fetch_fresh_hls_url(config, post["reddit_id"])
         hls_url = fresh_hls or post.get("hls_url")
@@ -154,24 +162,18 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
         if media_path:
             media_path = await asyncio.get_event_loop().run_in_executor(None, compress_video, media_path)
         if media_path is None:
-            logger.warning("Skipping video post %s: failed to download or compress", post["reddit_id"])
-            await mark_as_published(post["reddit_id"], 0)
-            return False
+            return await _drop_with_notice(config, post, "Video download/compress failed for")
     elif post["post_type"] == "gallery" and post.get("media_urls"):
         paths = [await download_image(url) for url in post["media_urls"]]
         media_paths = [p for p in paths if p is not None] or None
         if media_paths is None:
-            logger.warning("Skipping gallery post %s: failed to download any images", post["reddit_id"])
-            await mark_as_published(post["reddit_id"], 0)
-            return False
+            return await _drop_with_notice(config, post, "Gallery download failed for")
     elif post["post_type"] == "link" and post.get("content_url") and _is_video_url(post["content_url"]):
         media_path = await asyncio.get_event_loop().run_in_executor(None, download_video, post["content_url"])
         if media_path:
             media_path = await asyncio.get_event_loop().run_in_executor(None, compress_video, media_path)
         if media_path is None:
-            logger.warning("Skipping link-video post %s: failed to download or compress", post["reddit_id"])
-            await mark_as_published(post["reddit_id"], 0)
-            return False
+            return await _drop_with_notice(config, post, "Link-video download/compress failed for")
 
     try:
         msg_id = await publish_post(config, post, media_path=media_path, media_paths=media_paths)
@@ -184,8 +186,8 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
         poller.register_post(msg_id, post)
         asyncio.create_task(_publish_comments_delayed(config, poller, post, msg_id))
     else:
-        logger.warning("Skipping post %s: publish failed", post["reddit_id"])
-        await mark_as_published(post["reddit_id"], 0)
+        # Publishing failed — send a link-only notice so the post isn't silently lost.
+        await _drop_with_notice(config, post, "Publish failed for")
 
     if media_path:
         cleanup(media_path)

--- a/src/publisher/telegram.py
+++ b/src/publisher/telegram.py
@@ -71,9 +71,17 @@ async def _post_message(
     response = await client.post(url, data=data, files=files)
     if _is_parse_error(response) and text_field in data:
         logger.info("%s hit an HTML parse error, retrying as plain text", method)
-        plain = {k: v for k, v in data.items() if k != "parse_mode"}
-        plain[text_field] = _html_to_plain(data[text_field])
-        response = await client.post(url, data=plain, files=files)
+        data = {k: v for k, v in data.items() if k != "parse_mode"}
+        data[text_field] = _html_to_plain(data[text_field])
+        response = await client.post(url, data=data, files=files)
+    # Retry on rate-limiting so a 429 doesn't permanently drop the post (galleries already do this).
+    for _ in range(3):
+        if response.status_code != 429:
+            break
+        retry_after = response.json().get("parameters", {}).get("retry_after", 5)
+        logger.info("%s rate-limited, sleeping %ds", method, retry_after)
+        await asyncio.sleep(retry_after + 1)
+        response = await client.post(url, data=data, files=files)
     if response.status_code == 200:
         return response.json()["result"]["message_id"], response
     return None, response
@@ -502,6 +510,25 @@ async def _publish_link(
             return msg_id
 
     return await _send_message(client, config, caption, reply_markup=reply_markup)
+
+
+async def publish_failed_notice(config: Config, post: dict) -> int | None:
+    """Send a link-only notice when a post could not be published normally.
+
+    Ensures a post never vanishes silently: even if media/caption sending fails, its Reddit
+    link (and external link, for link posts) reaches Telegram for manual review later.
+    """
+    lines = ["⚠️ <b>Не удалось опубликовать пост</b>"]
+    title = (post.get("title") or "").strip()
+    if title:
+        lines.append(_html.escape(title))
+    lines.append(f'<a href="{post["url"]}">{post["url"]}</a>')
+    content_url = post.get("content_url")
+    if content_url and content_url != post["url"]:
+        lines.append(_html.escape(content_url))
+    text = "\n".join(lines)
+    async with httpx.AsyncClient(timeout=None) as client:
+        return await _send_message(client, config, text)
 
 
 async def publish_post(

--- a/tests/test_main_publish_one.py
+++ b/tests/test_main_publish_one.py
@@ -1,0 +1,73 @@
+"""Tests for publish_one's failure handling: no post must vanish without a link reaching Telegram."""
+
+import src.main as main
+from src.config import Config
+from src.publisher.poller import UpdatePoller
+
+CONFIG = Config(telegram_bot_token="testtoken", telegram_chat_id="-100", database_url="postgresql://test")
+
+LINK_POST = {
+    "reddit_id": "t3_lnk",
+    "subreddit": "news",
+    "title": "Headline",
+    "url": "https://reddit.com/r/news/comments/lnk/headline/",
+    "content_url": "https://example.com/article",
+    "post_type": "text",
+    "selftext": "body",
+}
+
+
+async def test_publish_one_sends_notice_when_publish_fails(monkeypatch):
+    published: dict = {}
+    notices: list = []
+
+    async def fake_get(limit=None, max_age_hours=24):
+        return [dict(LINK_POST)]
+
+    async def fake_publish_post(*_a, **_k):
+        return None  # publishing fails
+
+    async def fake_notice(_config, post):
+        notices.append(post["reddit_id"])
+        return 999
+
+    async def fake_mark(reddit_id, msg_id):
+        published[reddit_id] = msg_id
+
+    monkeypatch.setattr(main, "get_unpublished_posts", fake_get)
+    monkeypatch.setattr(main, "publish_post", fake_publish_post)
+    monkeypatch.setattr(main, "publish_failed_notice", fake_notice)
+    monkeypatch.setattr(main, "mark_as_published", fake_mark)
+
+    result = await main.publish_one(CONFIG, UpdatePoller(CONFIG))
+
+    assert result is False  # not published normally
+    assert notices == ["t3_lnk"]  # link-only notice was sent
+    assert published == {"t3_lnk": 999}  # marked handled with the notice's message id
+
+
+async def test_publish_one_sends_notice_when_media_download_fails(monkeypatch):
+    notices: list = []
+
+    async def fake_get(limit=None, max_age_hours=24):
+        return [{**LINK_POST, "post_type": "image", "content_url": "https://i.redd.it/x.jpg"}]
+
+    async def fake_download_image(_url):
+        return None  # download fails
+
+    async def fake_notice(_config, post):
+        notices.append(post["reddit_id"])
+        return 5
+
+    async def fake_mark(_reddit_id, _msg_id):
+        return None
+
+    monkeypatch.setattr(main, "get_unpublished_posts", fake_get)
+    monkeypatch.setattr(main, "download_image", fake_download_image)
+    monkeypatch.setattr(main, "publish_failed_notice", fake_notice)
+    monkeypatch.setattr(main, "mark_as_published", fake_mark)
+
+    result = await main.publish_one(CONFIG, UpdatePoller(CONFIG))
+
+    assert result is False
+    assert notices == ["t3_lnk"]  # image posts that fail to download still send their link

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2,7 +2,12 @@ import respx
 from httpx import Response
 
 from src.config import Config
-from src.publisher.telegram import _build_media_texts, publish_post
+from src.publisher.telegram import _build_media_texts, publish_failed_notice, publish_post
+
+
+async def _no_sleep(*_args, **_kwargs):
+    return None
+
 
 CONFIG = Config(
     telegram_bot_token="testtoken",
@@ -73,9 +78,37 @@ async def test_publish_text_post_returns_message_id():
 
 
 @respx.mock
-async def test_publish_text_post_on_api_failure():
-    respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(
+async def test_publish_text_post_on_api_failure(monkeypatch):
+    # Persistent 429 → give up after retries and return None (retries mustn't hang on real sleeps).
+    monkeypatch.setattr("src.publisher.telegram.asyncio.sleep", _no_sleep)
+    route = respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(
         return_value=Response(429, json={"description": "Too Many Requests"})
     )
     msg_id = await publish_post(CONFIG, BASE_POST)
     assert msg_id is None
+    assert route.call_count > 1  # initial send + retries
+
+
+@respx.mock
+async def test_publish_text_post_retries_then_succeeds_on_429(monkeypatch):
+    monkeypatch.setattr("src.publisher.telegram.asyncio.sleep", _no_sleep)
+    responses = [
+        Response(429, json={"parameters": {"retry_after": 1}}),
+        Response(200, json={"result": {"message_id": 77}}),
+    ]
+    respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(side_effect=responses)
+    msg_id = await publish_post(CONFIG, BASE_POST)
+    assert msg_id == 77
+
+
+@respx.mock
+async def test_publish_failed_notice_sends_post_link():
+    route = respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(
+        return_value=Response(200, json={"result": {"message_id": 5}})
+    )
+    link_post = {**BASE_POST, "post_type": "link", "content_url": "https://example.com/article"}
+    msg_id = await publish_failed_notice(CONFIG, link_post)
+    assert msg_id == 5
+    sent = route.calls.last.request.content.decode()
+    assert "reddit.com%2Fr%2Fprogramming" in sent or "reddit.com/r/programming" in sent
+    assert "example.com" in sent


### PR DESCRIPTION
## Summary

This recovers a fix that was pushed to the #77 branch **after** that PR had already been merged, so it never landed on `main`.

- **Retry on 429.** `_post_message` (the single choke point for all `sendMessage`/`sendPhoto`/`sendVideo`/`sendAnimation` calls) now retries on Telegram rate-limiting, honoring `retry_after`. Previously only media groups retried, so a rate-limited text/link post returned `None` and was silently dropped — matching the reported "posts without media don't arrive".
- **Link-only fallback.** When a post can't be published (send failure or media download failure), a short notice with the Reddit link (and external link for link posts) is sent to Telegram via `publish_failed_notice`, so no post vanishes without a trace for later review.

## Testing

`uv run pytest` — 138 passed. Adds coverage for the 429 retry, `publish_failed_notice`, and both `publish_one` drop paths.