### PR TITLE
Send link-post previews as downloaded bytes so large images reach Telegram

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -144,6 +144,7 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
     post = posts[0]
     media_path = None
     media_paths = None
+    photo_path = None
 
     if post["post_type"] == "image" and post.get("content_url"):
         media_path = await download_image(post["content_url"])
@@ -174,9 +175,14 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
             media_path = await asyncio.get_event_loop().run_in_executor(None, compress_video, media_path)
         if media_path is None:
             return await _drop_with_notice(config, post, "Link-video download/compress failed for")
+    elif post["post_type"] == "link" and post.get("preview_url"):
+        # Download the preview ourselves and send it as bytes — Telegram can't fetch
+        # external-preview.redd.it by URL. On failure keep photo_path=None (not a drop):
+        # _publish_link degrades to URL send, then plain text.
+        photo_path = await download_image(post["preview_url"])
 
     try:
-        msg_id = await publish_post(config, post, media_path=media_path, media_paths=media_paths)
+        msg_id = await publish_post(config, post, media_path=media_path, media_paths=media_paths, photo_path=photo_path)
     except Exception as e:
         logger.warning("Failed to publish post %s: %s", post["reddit_id"], e)
         msg_id = None
@@ -194,6 +200,8 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
     if media_paths:
         for p in media_paths:
             cleanup(p)
+    if photo_path:
+        cleanup(photo_path)
 
     return bool(msg_id)  # True=published, False=skipped
 

--- a/src/publisher/telegram.py
+++ b/src/publisher/telegram.py
@@ -498,10 +498,18 @@ async def _publish_link(
     caption: str,
     media_path: Path | None = None,
     *,
+    photo_path: Path | None = None,
     reply_markup: str | None = None,
 ) -> int | None:
     if media_path:
         return await _send_video(client, config, caption, media_path, reply_markup=reply_markup)
+
+    # Prefer sending the preview we downloaded ourselves as bytes: Telegram can't fetch
+    # external-preview.redd.it by URL (hotlink-protected → 403), so a URL send returns None.
+    if photo_path:
+        msg_id = await _send_photo(client, config, caption, photo_path, reply_markup=reply_markup)
+        if msg_id:
+            return msg_id
 
     preview_url = post.get("preview_url")
     if preview_url:
@@ -536,6 +544,7 @@ async def publish_post(
     post: dict,
     media_path: Path | None = None,
     media_paths: list[Path] | None = None,
+    photo_path: Path | None = None,
 ) -> int | None:
     caption, overflow = _build_media_texts(post, config)
     post_type = post["post_type"]
@@ -552,7 +561,7 @@ async def publish_post(
         elif post_type == "text":
             msg_id = await _publish_text_messages(client, config, post)
         elif post_type == "link":
-            msg_id = await _publish_link(client, config, post, caption, media_path)
+            msg_id = await _publish_link(client, config, post, caption, media_path, photo_path=photo_path)
         else:
             msg_id = await _send_message(client, config, caption)
 

--- a/src/scraper/media.py
+++ b/src/scraper/media.py
@@ -11,15 +11,18 @@ import yt_dlp
 logger = logging.getLogger(__name__)
 
 TMP_DIR = Path("tmp")
+# Reddit's preview hosts (external-preview.redd.it) 403 non-browser clients, so present as one.
+BROWSER_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
 
 async def download_image(url: str) -> Path | None:
     try:
         async with httpx.AsyncClient(timeout=30) as client:
-            response = await client.get(url)
+            response = await client.get(url, headers={"User-Agent": BROWSER_UA})
             response.raise_for_status()
 
         suffix = Path(url.split("?")[0]).suffix or ".jpg"
+        TMP_DIR.mkdir(exist_ok=True)  # noqa: ASYNC240
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix, dir=TMP_DIR) as tmp_file:
             tmp_file.write(response.content)
             return Path(tmp_file.name)

--- a/tests/test_main_publish_one.py
+++ b/tests/test_main_publish_one.py
@@ -1,8 +1,20 @@
 """Tests for publish_one's failure handling: no post must vanish without a link reaching Telegram."""
 
+from pathlib import Path
+
 import src.main as main
 from src.config import Config
 from src.publisher.poller import UpdatePoller
+
+PREVIEW_LINK_POST = {
+    "reddit_id": "t3_lnk",
+    "subreddit": "news",
+    "title": "Headline",
+    "url": "https://reddit.com/r/news/comments/lnk/headline/",
+    "content_url": "https://bbc.co.uk/article",
+    "post_type": "link",
+    "preview_url": "https://external-preview.redd.it/x.jpg",
+}
 
 CONFIG = Config(telegram_bot_token="testtoken", telegram_chat_id="-100", database_url="postgresql://test")
 
@@ -71,3 +83,78 @@ async def test_publish_one_sends_notice_when_media_download_fails(monkeypatch):
 
     assert result is False
     assert notices == ["t3_lnk"]  # image posts that fail to download still send their link
+
+
+async def test_publish_one_downloads_link_preview_and_passes_photo_path(monkeypatch):
+    captured: dict = {}
+    cleaned: list = []
+    fake_photo = Path("tmp/fake_preview.jpg")
+
+    async def fake_get(limit=None, max_age_hours=24):
+        return [dict(PREVIEW_LINK_POST)]
+
+    async def fake_download_image(url):
+        assert url == PREVIEW_LINK_POST["preview_url"]
+        return fake_photo
+
+    async def fake_publish_post(config, post, media_path=None, media_paths=None, photo_path=None):
+        captured["photo_path"] = photo_path
+        return 10
+
+    async def fake_mark(_reddit_id, _msg_id):
+        return None
+
+    async def fake_comments(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(main, "get_unpublished_posts", fake_get)
+    monkeypatch.setattr(main, "download_image", fake_download_image)
+    monkeypatch.setattr(main, "publish_post", fake_publish_post)
+    monkeypatch.setattr(main, "mark_as_published", fake_mark)
+    monkeypatch.setattr(main, "_publish_comments_delayed", fake_comments)
+    monkeypatch.setattr(main, "cleanup", lambda p: cleaned.append(p))
+
+    result = await main.publish_one(CONFIG, UpdatePoller(CONFIG))
+
+    assert result is True
+    assert captured["photo_path"] == fake_photo  # downloaded preview reached publish_post as bytes
+    assert fake_photo in cleaned  # temp preview file cleaned up
+
+
+async def test_publish_one_link_preview_download_failure_is_not_dropped(monkeypatch):
+    captured: dict = {}
+    notices: list = []
+
+    async def fake_get(limit=None, max_age_hours=24):
+        return [dict(PREVIEW_LINK_POST)]
+
+    async def fake_download_image(_url):
+        return None  # preview download fails
+
+    async def fake_publish_post(config, post, media_path=None, media_paths=None, photo_path=None):
+        captured["photo_path"] = photo_path
+        return 10
+
+    async def fake_notice(_config, post):
+        notices.append(post["reddit_id"])
+        return 5
+
+    async def fake_mark(_reddit_id, _msg_id):
+        return None
+
+    async def fake_comments(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(main, "get_unpublished_posts", fake_get)
+    monkeypatch.setattr(main, "download_image", fake_download_image)
+    monkeypatch.setattr(main, "publish_post", fake_publish_post)
+    monkeypatch.setattr(main, "publish_failed_notice", fake_notice)
+    monkeypatch.setattr(main, "mark_as_published", fake_mark)
+    monkeypatch.setattr(main, "_publish_comments_delayed", fake_comments)
+    monkeypatch.setattr(main, "cleanup", lambda _p: None)
+
+    result = await main.publish_one(CONFIG, UpdatePoller(CONFIG))
+
+    assert result is True  # still published (degrades to URL/text inside _publish_link)
+    assert captured["photo_path"] is None  # publish_post called with no photo
+    assert notices == []  # a failed preview download must NOT drop the post

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -2,7 +2,10 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from src.scraper.media import _get_duration, _get_ffmpeg, cleanup
+import respx
+from httpx import Response
+
+from src.scraper.media import _get_duration, _get_ffmpeg, cleanup, download_image
 
 # --- _get_ffmpeg ---
 
@@ -101,6 +104,28 @@ async def test_download_video_direct_skips_hls_when_no_ffmpeg():
     # With no ffmpeg, falls back to direct download
     if result:
         cleanup(result)
+
+
+# --- download_image ---
+
+
+@respx.mock
+async def test_download_image_sends_browser_user_agent():
+    route = respx.get("https://external-preview.redd.it/big.jpg").mock(
+        return_value=Response(200, content=b"\xff\xd8\xff imagebytes")
+    )
+    path = await download_image("https://external-preview.redd.it/big.jpg?width=1080&s=SIG")
+    assert path is not None
+    ua = route.calls.last.request.headers.get("user-agent", "")
+    assert "Mozilla" in ua and "Chrome" in ua
+    cleanup(path)
+
+
+@respx.mock
+async def test_download_image_returns_none_on_403():
+    respx.get("https://external-preview.redd.it/blocked.jpg").mock(return_value=Response(403))
+    path = await download_image("https://external-preview.redd.it/blocked.jpg")
+    assert path is None
 
 
 async def test_download_video_direct_returns_none_on_failure():

--- a/tests/test_publisher_extended.py
+++ b/tests/test_publisher_extended.py
@@ -13,6 +13,7 @@ from src.publisher.telegram import (
     _chunk_text_evenly,
     _html_to_plain,
     _md_to_telegram_html,
+    _publish_link,
     _publish_text_messages,
     _send_message,
     _take_raw_chunk,
@@ -282,6 +283,48 @@ async def test_media_post_not_dropped_on_caption_parse_error():
     msg_id = await publish_post(CONFIG, post)
     assert msg_id == 55
     assert calls["n"] == 2
+
+
+# --- _publish_link (downloaded preview) ---
+
+
+@respx.mock
+async def test_publish_link_sends_downloaded_photo_as_bytes(tmp_path):
+    photo = tmp_path / "preview.jpg"
+    photo.write_bytes(b"\xff\xd8\xff imagebytes")
+    photo_route = respx.post("https://api.telegram.org/bottesttoken/sendPhoto").mock(
+        return_value=Response(200, json={"result": {"message_id": 71}})
+    )
+    msg_route = respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(
+        return_value=Response(200, json={"result": {"message_id": 99}})
+    )
+    post = {**BASE_POST, "post_type": "link", "preview_url": "https://external-preview.redd.it/x.jpg"}
+
+    async with httpx.AsyncClient() as client:
+        msg_id = await _publish_link(client, CONFIG, post, "caption", photo_path=photo)
+
+    assert msg_id == 71
+    # Bytes are sent as multipart/form-data (files=), not a URL form field.
+    assert "multipart/form-data" in photo_route.calls.last.request.headers.get("content-type", "")
+    assert not msg_route.called  # no text fallback when the photo succeeds
+
+
+@respx.mock
+async def test_publish_link_falls_back_to_url_then_text(tmp_path):
+    photo = tmp_path / "preview.jpg"
+    photo.write_bytes(b"\xff\xd8\xff imagebytes")
+    # Both the byte send and the URL send fail → degrade to plain text.
+    respx.post("https://api.telegram.org/bottesttoken/sendPhoto").mock(return_value=Response(400))
+    msg_route = respx.post("https://api.telegram.org/bottesttoken/sendMessage").mock(
+        return_value=Response(200, json={"result": {"message_id": 42}})
+    )
+    post = {**BASE_POST, "post_type": "link", "preview_url": "https://external-preview.redd.it/x.jpg"}
+
+    async with httpx.AsyncClient() as client:
+        msg_id = await _publish_link(client, CONFIG, post, "caption", photo_path=photo)
+
+    assert msg_id == 42
+    assert msg_route.called  # fell all the way back to text
 
 
 # --- _publish_text_messages ---


### PR DESCRIPTION
## Контекст

После PR #77 у ссылочных (link) постов `preview_url` стал большим `og:image` (`external-preview.redd.it/...`), но отправлялся в Telegram **по URL**. `external-preview.redd.it` применяет hotlink-защиту и отдаёт 403 не-браузерным клиентам (Telegram фетчит URL сам) → отправка фото падала → откат на текст **без картинки**. Старый маленький thumbnail (`b.thumbs.redditmedia.com`) такой защиты не имел — поэтому раньше приходила хотя бы маленькая картинка, а теперь никакой.

## Изменения

- **`src/scraper/media.py`** — `download_image` теперь шлёт браузерный `User-Agent` (иначе reddit-превью отдаёт 403 и нам самим) и создаёт `TMP_DIR` при необходимости.
- **`src/publisher/telegram.py`** — `_publish_link` получил параметр `photo_path`: скачанное превью отправляется **байтами** через `_send_photo`. Порядок деградации: байты → по URL → текст (поведение не хуже прежнего). Параметр прокинут через `publish_post`.
- **`src/main.py`** — `publish_one` для обычных ссылок с `preview_url` скачивает картинку сам и передаёт как `photo_path`; при неудаче скачивания пост **не** дропается (мягкая деградация), временный файл чистится.

Схема БД не меняется. Скачивание опирается на то, что бот уже успешно качает страницу поста тем же UA, чтобы достать `og:image`, — значит и картинку скачает.

## Тесты

+6 тестов: `User-Agent` в `download_image`; байтовая отправка и fallback в `_publish_link`; скачивание превью и обработка неудачи в `publish_one`. Вся сюита — 144 passed, `ruff` чистый.

## Проверка end-to-end

Прямой доступ к old.reddit с локального IP отдаёт 403 (работает только на Railway), поэтому окончательно убедиться, что ссылочный пост приходит с большой картинкой, можно только на проде.