### PR TITLE
Recover text body for media posts; enrich pages only for new posts

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ from src.scraper.media import (
     download_video,
     download_video_direct,
 )
-from src.scraper.reddit import fetch_fresh_hls_url, fetch_top_comments, fetch_top_posts
+from src.scraper.reddit import enrich_post, fetch_fresh_hls_url, fetch_top_comments, fetch_top_posts
 from src.webapp.server import start_webapp_task
 
 logging.basicConfig(
@@ -60,13 +60,18 @@ async def scrape_new_posts(config) -> None:
     try:
         posts = await fetch_top_posts(config)
         posts_found = len(posts)
-        for post in posts:
-            if config.skip_nsfw and post["is_nsfw"]:
-                continue
-            if await is_post_exists(post["reddit_id"]):
-                continue
-            await insert_post(post)
-            posts_new += 1
+        async with httpx.AsyncClient(timeout=30, follow_redirects=True, http2=True) as client:
+            for post in posts:
+                if config.skip_nsfw and post["is_nsfw"]:
+                    continue
+                if await is_post_exists(post["reddit_id"]):
+                    continue
+                # New post: fetch its page once to recover body/gallery/preview the listing omits.
+                # Space fetches out so old.reddit doesn't rate-limit the burst.
+                await asyncio.sleep(2)
+                await enrich_post(client, post)
+                await insert_post(post)
+                posts_new += 1
         logger.info("Scrape done: found=%d new=%d", posts_found, posts_new)
     except Exception as e:
         error = str(e)

--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -95,11 +95,12 @@ def _parse_thing(thing) -> dict | None:
         hls_url = f"https://v.redd.it/{vid}/HLSPlaylist.m3u8"
         video_url = f"https://v.redd.it/{vid}/DASH_720.mp4"
 
+    # Any post type can carry a text body (Reddit's "image/link + text" posts), so read it
+    # regardless of type. The listing often omits it — enrich_post refetches the page then.
     selftext = None
-    if post_type == "text":
-        md = thing.select_one("div.usertext-body div.md")
-        if md:
-            selftext = md.get_text("\n", strip=True) or None
+    md = thing.select_one("div.usertext-body div.md")
+    if md:
+        selftext = md.get_text("\n", strip=True) or None
 
     preview_url = None
     thumb = thing.select_one("a.thumbnail img")
@@ -155,15 +156,15 @@ def _select_gallery_urls(page_html: str) -> list[str] | None:
     return [best[path][1] for path in order][:20] or None
 
 
-async def _fetch_gallery_images(client: httpx.AsyncClient, post: dict) -> list[str] | None:
-    """Fetch a gallery post's page and extract its image URLs."""
+async def _fetch_post_page(client: httpx.AsyncClient, post: dict) -> str | None:
+    """Fetch a post's own old.reddit page HTML (body, gallery tiles and og:image all live here)."""
     permalink = post["url"].removeprefix("https://reddit.com")
     try:
-        response = await _get_with_retry(client, f"{OLD_REDDIT}{permalink}", {}, label=f"gallery {post['reddit_id']}")
+        response = await _get_with_retry(client, f"{OLD_REDDIT}{permalink}", {}, label=f"page {post['reddit_id']}")
     except Exception:
-        logger.warning("Failed to fetch gallery images for %s", post["reddit_id"])
+        logger.warning("Failed to fetch post page for %s", post["reddit_id"])
         return None
-    return _select_gallery_urls(response.text)
+    return response.text
 
 
 def _select_selftext(page_html: str, reddit_id: str) -> str | None:
@@ -182,19 +183,32 @@ def _select_selftext(page_html: str, reddit_id: str) -> str | None:
     return md.get_text("\n", strip=True) or None
 
 
-async def _fetch_selftext(client: httpx.AsyncClient, post: dict) -> str | None:
-    """Fetch a text post's page to recover a body the listing HTML omitted.
+async def enrich_post(client: httpx.AsyncClient, post: dict) -> None:
+    """Fetch a new post's own page once to recover what the /top/ listing omits.
 
-    old.reddit's listing does not always inline the full self-text (long posts load it on
-    expand), so a title-only text post is refetched from its own page.
+    The listing does not reliably inline self-text (even for image/link posts that carry a body),
+    exposes only a tiny thumbnail for links, and never lists gallery tiles. Fetching the page once
+    fills all three. Called only for posts not yet in the DB, so a page is fetched at most once per
+    post instead of on every scrape.
     """
-    permalink = post["url"].removeprefix("https://reddit.com")
-    try:
-        response = await _get_with_retry(client, f"{OLD_REDDIT}{permalink}", {}, label=f"selftext {post['reddit_id']}")
-    except Exception:
-        logger.warning("Failed to fetch selftext for %s", post["reddit_id"])
-        return None
-    return _select_selftext(response.text, post["reddit_id"])
+    needs_gallery = post["post_type"] == "gallery"
+    needs_preview = post["post_type"] == "link" and bool(post.get("preview_url"))
+    needs_body = not post.get("selftext")
+    if not (needs_gallery or needs_preview or needs_body):
+        return
+
+    page = await _fetch_post_page(client, post)
+    if page is None:
+        return
+
+    if needs_body:
+        post["selftext"] = _select_selftext(page, post["reddit_id"])
+    if needs_gallery:
+        post["media_urls"] = _select_gallery_urls(page)
+    if needs_preview:
+        bigger = _select_preview_image(page)
+        if bigger:
+            post["preview_url"] = bigger
 
 
 def _select_preview_image(page_html: str) -> str | None:
@@ -215,42 +229,18 @@ def _select_preview_image(page_html: str) -> str | None:
     return url
 
 
-async def _fetch_preview_image(client: httpx.AsyncClient, post: dict) -> str | None:
-    """Fetch a link post's page to recover the large preview the listing thumbnail shrinks."""
-    permalink = post["url"].removeprefix("https://reddit.com")
-    try:
-        response = await _get_with_retry(client, f"{OLD_REDDIT}{permalink}", {}, label=f"preview {post['reddit_id']}")
-    except Exception:
-        logger.warning("Failed to fetch preview image for %s", post["reddit_id"])
-        return None
-    return _select_preview_image(response.text)
-
-
 async def fetch_top_posts(config: Config) -> list[dict]:
+    """Parse the /top/ listing into posts. Per-post page enrichment (body, gallery, preview)
+    happens later in enrich_post, only for posts new to the DB, to avoid refetching the whole
+    listing's pages on every scrape."""
     url = f"{OLD_REDDIT}/top/"
     params = {"t": "day", "limit": config.posts_limit}
 
     async with httpx.AsyncClient(timeout=30, follow_redirects=True, http2=True) as client:
         response = await _get_with_retry(client, url, params, label="top posts")
-        soup = BeautifulSoup(response.text, "html.parser")
-        posts = [post for thing in soup.select("div.thing") if (post := _parse_thing(thing))]
 
-        for post in posts:
-            if post["post_type"] == "gallery":
-                # Space out per-post page fetches so old.reddit doesn't rate-limit the burst.
-                await asyncio.sleep(2)
-                post["media_urls"] = await _fetch_gallery_images(client, post)
-            elif post["post_type"] == "text" and not post["selftext"]:
-                # Listing omitted the body — refetch the post page so it doesn't publish title-only.
-                await asyncio.sleep(2)
-                post["selftext"] = await _fetch_selftext(client, post)
-            elif post["post_type"] == "link" and post["preview_url"]:
-                # Listing only has a tiny thumbnail — refetch for the full-size og:image preview.
-                await asyncio.sleep(2)
-                bigger = await _fetch_preview_image(client, post)
-                if bigger:
-                    post["preview_url"] = bigger
-
+    soup = BeautifulSoup(response.text, "html.parser")
+    posts = [post for thing in soup.select("div.thing") if (post := _parse_thing(thing))]
     logger.info("Fetched %d posts from Reddit", len(posts))
     return posts
 

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -6,11 +6,9 @@ from httpx import Response
 
 from src.config import Config
 from src.scraper.reddit import (
-    _fetch_gallery_images,
-    _fetch_preview_image,
-    _fetch_selftext,
     _select_preview_image,
     _select_selftext,
+    enrich_post,
     fetch_fresh_hls_url,
     fetch_top_comments,
     fetch_top_posts,
@@ -115,46 +113,7 @@ async def test_fetch_top_comments_text_only_has_no_media():
     assert high["media_type"] is None
 
 
-# --- _fetch_gallery_images ---
-
-
-@respx.mock
-async def test_fetch_gallery_images_scopes_to_tiles_and_picks_largest_signed():
-    # Only the gallery tiles count: the largest signed width per image wins, unsigned variants
-    # are skipped, and images from comments / "read next" / thumbnail must NOT leak in.
-    page_html = (
-        '<div class="sitetable linklisting"><div class="thing">'
-        '<div class="media-preview-content">'
-        '<a class="gallery-item-thumbnail-link" href="https://preview.redd.it/aaa.jpg?width=1170&amp;s=BIG">'
-        '<img class="gallery-tile-content" src="https://preview.redd.it/aaa.jpg?width=108&amp;s=SMALL"/></a>'
-        '<a class="gallery-item-thumbnail-link" href="https://preview.redd.it/unsigned.jpg?width=140">'
-        '<img class="gallery-tile-content" src="https://preview.redd.it/bbb.jpg?width=960&amp;s=B"/></a>'
-        "</div></div></div>"
-        '<a class="thumbnail"><img src="https://preview.redd.it/THUMB.jpg?s=T"/></a>'
-        '<div class="commentarea"><div class="sitetable"><div class="comment"><div class="md">'
-        '<p><a href="https://preview.redd.it/COMMENT.jpg?s=CMT">&lt;image&gt;</a></p></div></div></div></div>'
-    )
-    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=page_html))
-    async with httpx.AsyncClient() as client:
-        urls = await _fetch_gallery_images(client, SAMPLE_POST)
-    assert urls == [
-        "https://preview.redd.it/aaa.jpg?width=1170&s=BIG",
-        "https://preview.redd.it/bbb.jpg?width=960&s=B",
-    ]
-    joined = " ".join(urls)
-    assert "COMMENT.jpg" not in joined
-    assert "THUMB.jpg" not in joined
-    assert "unsigned.jpg" not in joined
-
-
-@respx.mock
-async def test_fetch_gallery_images_none_on_error():
-    respx.get(COMMENTS_URL).mock(return_value=Response(500))
-    async with httpx.AsyncClient() as client:
-        assert await _fetch_gallery_images(client, SAMPLE_POST) is None
-
-
-# --- _select_selftext / _fetch_selftext ---
+# --- _select_selftext (page parser) ---
 
 POST_PAGE_HTML = (
     '<div class="content">'
@@ -166,6 +125,25 @@ POST_PAGE_HTML = (
     '<div class="usertext-body"><div class="md"><p>a comment body must be ignored</p></div></div>'
     "</div></div></div>"
     "</div>"
+)
+
+GALLERY_PAGE_HTML = (
+    '<div class="sitetable linklisting"><div class="thing">'
+    '<div class="media-preview-content">'
+    '<a class="gallery-item-thumbnail-link" href="https://preview.redd.it/aaa.jpg?width=1170&amp;s=BIG">'
+    '<img class="gallery-tile-content" src="https://preview.redd.it/aaa.jpg?width=108&amp;s=SMALL"/></a>'
+    '<a class="gallery-item-thumbnail-link" href="https://preview.redd.it/unsigned.jpg?width=140">'
+    '<img class="gallery-tile-content" src="https://preview.redd.it/bbb.jpg?width=960&amp;s=B"/></a>'
+    "</div></div></div>"
+    '<a class="thumbnail"><img src="https://preview.redd.it/THUMB.jpg?s=T"/></a>'
+    '<div class="commentarea"><div class="sitetable"><div class="comment"><div class="md">'
+    '<p><a href="https://preview.redd.it/COMMENT.jpg?s=CMT">&lt;image&gt;</a></p></div></div></div></div>'
+)
+
+PREVIEW_PAGE_HTML = (
+    "<html><head>"
+    '<meta property="og:image" content="https://external-preview.redd.it/big.jpg?width=1080&amp;s=SIG"/>'
+    "</head><body></body></html>"
 )
 
 
@@ -183,62 +161,6 @@ def test_select_selftext_none_when_thing_absent():
     assert _select_selftext(POST_PAGE_HTML, "t3_missing") is None
 
 
-@respx.mock
-async def test_fetch_selftext_returns_body():
-    post = {"reddit_id": "t3_txt", "url": "https://reddit.com/r/x/comments/txt/t/"}
-    respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(200, html=POST_PAGE_HTML))
-    async with httpx.AsyncClient() as client:
-        assert await _fetch_selftext(client, post) == "Recovered body line one.\nLine two."
-
-
-@respx.mock
-async def test_fetch_selftext_none_on_error():
-    post = {"reddit_id": "t3_txt", "url": "https://reddit.com/r/x/comments/txt/t/"}
-    respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(500))
-    async with httpx.AsyncClient() as client:
-        assert await _fetch_selftext(client, post) is None
-
-
-@respx.mock
-async def test_fetch_top_posts_recovers_missing_selftext_from_post_page():
-    # A self post whose listing HTML carries no body — the scraper must refetch the post page.
-    listing = (
-        '<div class="thing id-t3_txt self" data-fullname="t3_txt" data-author="carol"'
-        ' data-subreddit="AskReddit" data-url="https://www.reddit.com/r/AskReddit/comments/txt/q/"'
-        ' data-domain="self.AskReddit" data-permalink="/r/AskReddit/comments/txt/q/"'
-        ' data-score="10" data-comments-count="1" data-timestamp="1700000000000">'
-        '<p class="title"><a class="title" href="#">Just a title</a></p>'
-        "</div>"
-    )
-    respx.get("https://old.reddit.com/top/").mock(return_value=Response(200, html=listing))
-    respx.get("https://old.reddit.com/r/AskReddit/comments/txt/q/").mock(
-        return_value=Response(200, html=POST_PAGE_HTML)
-    )
-    posts = await fetch_top_posts(CONFIG)
-    txt = next(p for p in posts if p["reddit_id"] == "t3_txt")
-    assert txt["selftext"] == "Recovered body line one.\nLine two."
-
-
-@respx.mock
-async def test_fetch_top_posts_keeps_listing_selftext_without_refetch():
-    # When the listing already has the body, no post-page request should be needed.
-    route = respx.get("https://old.reddit.com/r/AskReddit/comments/text1/q/").mock(return_value=Response(500))
-    respx.get("https://old.reddit.com/top/").mock(return_value=Response(200, html=LISTING_HTML))
-    posts = await fetch_top_posts(CONFIG)
-    txt = next(p for p in posts if p["reddit_id"] == "t3_text1")
-    assert txt["selftext"] == "This is the body of the text post."
-    assert not route.called
-
-
-# --- _select_preview_image / _fetch_preview_image ---
-
-PREVIEW_PAGE_HTML = (
-    "<html><head>"
-    '<meta property="og:image" content="https://external-preview.redd.it/big.jpg?width=1080&amp;s=SIG"/>'
-    "</head><body></body></html>"
-)
-
-
 def test_select_preview_image_reads_og_image():
     assert _select_preview_image(PREVIEW_PAGE_HTML) == "https://external-preview.redd.it/big.jpg?width=1080&s=SIG"
 
@@ -252,63 +174,104 @@ def test_select_preview_image_none_when_absent():
     assert _select_preview_image("<html><head></head></html>") is None
 
 
+# --- enrich_post (per-new-post page enrichment) ---
+
+
 @respx.mock
-async def test_fetch_preview_image_returns_url():
-    post = {"reddit_id": "t3_lnk", "url": "https://reddit.com/r/x/comments/lnk/l/"}
-    respx.get("https://old.reddit.com/r/x/comments/lnk/l/").mock(return_value=Response(200, html=PREVIEW_PAGE_HTML))
+async def test_enrich_recovers_body_for_media_post():
+    # The core fix: an image post that carries a text body must get it from its page.
+    post = {"reddit_id": "t3_txt", "url": "https://reddit.com/r/x/comments/txt/t/", "post_type": "image"}
+    respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(200, html=POST_PAGE_HTML))
     async with httpx.AsyncClient() as client:
-        assert await _fetch_preview_image(client, post) == "https://external-preview.redd.it/big.jpg?width=1080&s=SIG"
+        await enrich_post(client, post)
+    assert post["selftext"] == "Recovered body line one.\nLine two."
 
 
 @respx.mock
-async def test_fetch_preview_image_none_on_error():
-    post = {"reddit_id": "t3_lnk", "url": "https://reddit.com/r/x/comments/lnk/l/"}
-    respx.get("https://old.reddit.com/r/x/comments/lnk/l/").mock(return_value=Response(500))
+async def test_enrich_recovers_body_for_text_post():
+    post = {"reddit_id": "t3_txt", "url": "https://reddit.com/r/x/comments/txt/t/", "post_type": "text"}
+    respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(200, html=POST_PAGE_HTML))
     async with httpx.AsyncClient() as client:
-        assert await _fetch_preview_image(client, post) is None
+        await enrich_post(client, post)
+    assert post["selftext"] == "Recovered body line one.\nLine two."
 
 
 @respx.mock
-async def test_fetch_top_posts_upgrades_link_thumbnail_to_og_image():
-    # A link post whose listing carries only a tiny thumbnail — the scraper must refetch the
-    # post page and replace preview_url with the full-size og:image.
-    listing = (
-        '<div class="thing id-t3_lnk link" data-fullname="t3_lnk" data-author="erin"'
-        ' data-subreddit="news" data-url="https://example.com/article" data-domain="example.com"'
-        ' data-permalink="/r/news/comments/lnk/headline/"'
-        ' data-score="321" data-comments-count="89" data-timestamp="1700000000000">'
-        '<a class="thumbnail" href="#"><img src="//b.thumbs.redditmedia.com/tiny.jpg"></a>'
-        '<a class="title" href="#">An external article</a>'
-        "</div>"
-    )
-    respx.get("https://old.reddit.com/top/").mock(return_value=Response(200, html=listing))
-    respx.get("https://old.reddit.com/r/news/comments/lnk/headline/").mock(
-        return_value=Response(200, html=PREVIEW_PAGE_HTML)
-    )
-    posts = await fetch_top_posts(CONFIG)
-    lnk = next(p for p in posts if p["reddit_id"] == "t3_lnk")
-    assert lnk["preview_url"] == "https://external-preview.redd.it/big.jpg?width=1080&s=SIG"
+async def test_enrich_body_none_on_page_error():
+    post = {
+        "reddit_id": "t3_txt",
+        "url": "https://reddit.com/r/x/comments/txt/t/",
+        "post_type": "image",
+        "selftext": None,
+    }
+    respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(500))
+    async with httpx.AsyncClient() as client:
+        await enrich_post(client, post)
+    assert post["selftext"] is None
 
 
 @respx.mock
-async def test_fetch_top_posts_keeps_thumbnail_when_og_image_missing():
-    # If the post page has no usable og:image, keep the listing thumbnail as a fallback.
-    listing = (
-        '<div class="thing id-t3_lnk link" data-fullname="t3_lnk" data-author="erin"'
-        ' data-subreddit="news" data-url="https://example.com/article" data-domain="example.com"'
-        ' data-permalink="/r/news/comments/lnk/headline/"'
-        ' data-score="321" data-comments-count="89" data-timestamp="1700000000000">'
-        '<a class="thumbnail" href="#"><img src="//b.thumbs.redditmedia.com/tiny.jpg"></a>'
-        '<a class="title" href="#">An external article</a>'
-        "</div>"
-    )
-    respx.get("https://old.reddit.com/top/").mock(return_value=Response(200, html=listing))
-    respx.get("https://old.reddit.com/r/news/comments/lnk/headline/").mock(
-        return_value=Response(200, html="<html><head></head></html>")
-    )
-    posts = await fetch_top_posts(CONFIG)
-    lnk = next(p for p in posts if p["reddit_id"] == "t3_lnk")
-    assert lnk["preview_url"] == "https://b.thumbs.redditmedia.com/tiny.jpg"
+async def test_enrich_skips_fetch_when_nothing_needed():
+    # Body already present, not a gallery or link — no page request should happen.
+    route = respx.get(COMMENTS_URL).mock(return_value=Response(500))
+    post = {**SAMPLE_POST, "post_type": "image", "selftext": "already have it", "preview_url": None}
+    async with httpx.AsyncClient() as client:
+        await enrich_post(client, post)
+    assert post["selftext"] == "already have it"
+    assert not route.called
+
+
+@respx.mock
+async def test_enrich_gallery_fills_media_urls_scoped_to_tiles():
+    # Largest signed width per image wins; unsigned variants and comment/thumbnail images excluded.
+    post = {**SAMPLE_POST, "post_type": "gallery", "selftext": "x", "preview_url": None, "media_urls": None}
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=GALLERY_PAGE_HTML))
+    async with httpx.AsyncClient() as client:
+        await enrich_post(client, post)
+    assert post["media_urls"] == [
+        "https://preview.redd.it/aaa.jpg?width=1170&s=BIG",
+        "https://preview.redd.it/bbb.jpg?width=960&s=B",
+    ]
+    joined = " ".join(post["media_urls"])
+    assert "COMMENT.jpg" not in joined and "THUMB.jpg" not in joined and "unsigned.jpg" not in joined
+
+
+@respx.mock
+async def test_enrich_upgrades_link_thumbnail_to_og_image():
+    post = {
+        **SAMPLE_POST,
+        "post_type": "link",
+        "selftext": "x",
+        "preview_url": "https://b.thumbs.redditmedia.com/tiny.jpg",
+    }
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=PREVIEW_PAGE_HTML))
+    async with httpx.AsyncClient() as client:
+        await enrich_post(client, post)
+    assert post["preview_url"] == "https://external-preview.redd.it/big.jpg?width=1080&s=SIG"
+
+
+@respx.mock
+async def test_enrich_keeps_thumbnail_when_og_image_missing():
+    post = {
+        **SAMPLE_POST,
+        "post_type": "link",
+        "selftext": "x",
+        "preview_url": "https://b.thumbs.redditmedia.com/tiny.jpg",
+    }
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html="<html><head></head></html>"))
+    async with httpx.AsyncClient() as client:
+        await enrich_post(client, post)
+    assert post["preview_url"] == "https://b.thumbs.redditmedia.com/tiny.jpg"
+
+
+@respx.mock
+async def test_enrich_link_without_preview_skips_fetch():
+    # A link post with no listing thumbnail and an existing body needs no page fetch.
+    route = respx.get(COMMENTS_URL).mock(return_value=Response(500))
+    post = {**SAMPLE_POST, "post_type": "link", "selftext": "x", "preview_url": None}
+    async with httpx.AsyncClient() as client:
+        await enrich_post(client, post)
+    assert not route.called
 
 
 # --- fetch_fresh_hls_url ---

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -1,0 +1,75 @@
+"""scrape_new_posts must enrich (fetch each post's page) only for posts new to the DB."""
+
+import src.main as main
+from src.config import Config
+
+CONFIG = Config(telegram_bot_token="t", telegram_chat_id="t", database_url="postgresql://test", skip_nsfw=True)
+
+
+def _post(rid, **extra):
+    return {"reddit_id": rid, "is_nsfw": False, **extra}
+
+
+async def test_scrape_enriches_and_inserts_only_new_posts(monkeypatch):
+    enriched: list = []
+    inserted: list = []
+    existing = {"t3_old"}
+
+    async def fake_fetch(_config):
+        return [_post("t3_old"), _post("t3_new")]
+
+    async def fake_exists(rid):
+        return rid in existing
+
+    async def fake_enrich(_client, post):
+        enriched.append(post["reddit_id"])
+
+    async def fake_insert(post):
+        inserted.append(post["reddit_id"])
+
+    async def fake_log(**_k):
+        return None
+
+    async def fake_sleep(_s):
+        return None
+
+    monkeypatch.setattr(main, "fetch_top_posts", fake_fetch)
+    monkeypatch.setattr(main, "is_post_exists", fake_exists)
+    monkeypatch.setattr(main, "enrich_post", fake_enrich)
+    monkeypatch.setattr(main, "insert_post", fake_insert)
+    monkeypatch.setattr(main, "log_scrape", fake_log)
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+
+    await main.scrape_new_posts(CONFIG)
+
+    assert enriched == ["t3_new"]  # the already-stored post is not refetched
+    assert inserted == ["t3_new"]
+
+
+async def test_scrape_skips_nsfw_before_enriching(monkeypatch):
+    enriched: list = []
+
+    async def fake_fetch(_config):
+        return [{"reddit_id": "t3_x", "is_nsfw": True}]
+
+    async def fake_exists(_rid):
+        return False
+
+    async def fake_enrich(_client, post):
+        enriched.append(post["reddit_id"])
+
+    async def fake_insert(_post):
+        return None
+
+    async def fake_log(**_k):
+        return None
+
+    monkeypatch.setattr(main, "fetch_top_posts", fake_fetch)
+    monkeypatch.setattr(main, "is_post_exists", fake_exists)
+    monkeypatch.setattr(main, "enrich_post", fake_enrich)
+    monkeypatch.setattr(main, "insert_post", fake_insert)
+    monkeypatch.setattr(main, "log_scrape", fake_log)
+
+    await main.scrape_new_posts(CONFIG)
+
+    assert enriched == []  # NSFW filtered out, never fetched


### PR DESCRIPTION
## Контекст

Медиа-посты (картинка/видео/гиф/галерея) с текстовым телом (формат Reddit «медиа + текст») приходили в Telegram только с заголовком — тело терялось. Причина: `selftext` извлекался только для `post_type == "text"`, у медиа-постов тело всегда было `None`.

## Изменения

- **`_parse_thing`** — тело поста читается для **всех** типов, а не только text.
- **Единая догрузка страницы** — три функции (`_fetch_gallery_images` / `_fetch_selftext` / `_fetch_preview_image`) заменены одной `enrich_post`, которая фетчит страницу поста один раз и достаёт из неё тело, тайлы галереи и большое превью (og:image).
- **Догрузка только для новых постов** — обогащение перенесено из `fetch_top_posts` (шло для всех 50 постов каждые 20 минут, включая давно сохранённые) в `scrape_new_posts`, **после** дедупликации `is_post_exists`. Теперь страница поста фетчится максимум один раз за его жизнь, а не каждый цикл — это вернуло текст медиа-постов и заодно резко снизило нагрузку на Reddit (риск 403).

Схема БД не меняется.

## Тесты

Тесты reddit переписаны под `enrich_post` (восстановление тела для медиа/text, галерея, апгрейд превью, пропуск фетча когда ничего не нужно). Новый `tests/test_scrape.py`: обогащаются/вставляются только новые посты, NSFW отсекается до фетча. Вся сюита — 138 passed, `ruff` чистый.

## Проверка end-to-end

Прямой доступ к old.reddit с локального IP отдаёт 403 (работает только на Railway), поэтому логика верифицирована на фикстурах; окончательно подтвердится на проде.

## Примечание

Отдельная ветка от `main`; PR #79 (превью ссылок байтами) ещё открыт. Пересечение минимально — при мёрже второго возможен тривиальный конфликт импортов в `main.py`.