### PR TITLE
Reconstruct markdown from rendered post HTML so bodies keep paragraphs and emphasis

### DIFF
--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -5,7 +5,7 @@ import re
 from datetime import UTC, datetime
 
 import httpx
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString, Tag
 
 from src.config import Config
 
@@ -67,6 +67,59 @@ def _abs_url(url: str | None) -> str | None:
     return url
 
 
+_INLINE_MD = {"strong": "**", "b": "**", "em": "*", "i": "*", "del": "~~", "s": "~~", "strike": "~~", "code": "`"}
+
+
+def _html_to_markdown(node: Tag) -> str:
+    """Turn an old.reddit rendered ``div.md`` subtree back into Reddit markdown.
+
+    The listing/page only exposes the *rendered* HTML, but the Telegram publisher expects
+    markdown (that is how bodies arrived from the old JSON API). Reconstructing markdown keeps
+    paragraph breaks, links and emphasis so the existing markdown→Telegram pipeline formats
+    bodies exactly as it did before the switch to HTML scraping.
+    """
+    out: list[str] = []
+    for child in node.children:
+        if isinstance(child, NavigableString):
+            out.append(str(child))
+            continue
+        if not isinstance(child, Tag):
+            continue
+        name = child.name
+        inner = _html_to_markdown(child)
+        if name == "p":
+            out.append(inner.strip() + "\n\n")
+        elif name in _INLINE_MD:
+            marker = _INLINE_MD[name]
+            out.append(f"{marker}{inner}{marker}")
+        elif name == "a":
+            out.append(f"[{inner}]({child.get('href', '')})")
+        elif name == "br":
+            out.append("\n")
+        elif name in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            out.append(f"# {inner.strip()}\n\n")
+        elif name == "blockquote":
+            quoted = "\n".join(f"> {line}" for line in inner.strip().split("\n"))
+            out.append(quoted + "\n\n")
+        elif name == "li":
+            out.append(f"- {inner.strip()}\n")
+        elif name in ("ul", "ol"):
+            out.append(inner + "\n")
+        elif name == "pre":
+            out.append(f"```\n{child.get_text().strip()}\n```\n\n")
+        elif name == "hr":
+            out.append("\n---\n\n")
+        else:
+            out.append(inner)
+    return "".join(out)
+
+
+def _selftext_from_md(md: Tag) -> str | None:
+    """Extract a post body as markdown from its rendered ``div.md`` element."""
+    text = re.sub(r"\n{3,}", "\n\n", _html_to_markdown(md)).strip()
+    return text or None
+
+
 def _parse_thing(thing) -> dict | None:
     """Parse one old.reddit ``div.thing`` link element into a post dict."""
     if thing.get("data-promoted") == "true":
@@ -100,7 +153,7 @@ def _parse_thing(thing) -> dict | None:
     selftext = None
     md = thing.select_one("div.usertext-body div.md")
     if md:
-        selftext = md.get_text("\n", strip=True) or None
+        selftext = _selftext_from_md(md)
 
     preview_url = None
     thumb = thing.select_one("a.thumbnail img")
@@ -180,7 +233,7 @@ def _select_selftext(page_html: str, reddit_id: str) -> str | None:
     md = thing.select_one("div.expando div.usertext-body div.md") or thing.select_one("div.usertext-body div.md")
     if not md:
         return None
-    return md.get_text("\n", strip=True) or None
+    return _selftext_from_md(md)
 
 
 async def enrich_post(client: httpx.AsyncClient, post: dict) -> None:

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -2,17 +2,24 @@ from pathlib import Path
 
 import httpx
 import respx
+from bs4 import BeautifulSoup
 from httpx import Response
 
 from src.config import Config
 from src.scraper.reddit import (
     _select_preview_image,
     _select_selftext,
+    _selftext_from_md,
     enrich_post,
     fetch_fresh_hls_url,
     fetch_top_comments,
     fetch_top_posts,
 )
+
+
+def _md(html: str) -> str | None:
+    return _selftext_from_md(BeautifulSoup(f'<div class="md">{html}</div>', "html.parser").select_one("div.md"))
+
 
 LISTING_HTML = Path("tests/fixtures/old_reddit_top.html").read_text()
 COMMENTS_HTML = Path("tests/fixtures/old_reddit_comments.html").read_text()
@@ -149,7 +156,7 @@ PREVIEW_PAGE_HTML = (
 
 def test_select_selftext_scoped_to_post_thing():
     body = _select_selftext(POST_PAGE_HTML, "t3_txt")
-    assert body == "Recovered body line one.\nLine two."
+    assert body == "Recovered body line one.\n\nLine two."
 
 
 def test_select_selftext_ignores_comment_bodies():
@@ -159,6 +166,34 @@ def test_select_selftext_ignores_comment_bodies():
 
 def test_select_selftext_none_when_thing_absent():
     assert _select_selftext(POST_PAGE_HTML, "t3_missing") is None
+
+
+# --- _selftext_from_md (rendered HTML -> markdown, restoring paragraphs/emphasis) ---
+
+
+def test_md_paragraphs_separated_by_blank_line():
+    assert _md("<p>First paragraph.</p><p>Second paragraph.</p>") == "First paragraph.\n\nSecond paragraph."
+
+
+def test_md_soft_breaks_become_newlines():
+    assert _md("<p>But.<br/>It.<br/>Ain't.</p>") == "But.\nIt.\nAin't."
+
+
+def test_md_emphasis_and_links_become_markdown():
+    body = _md('<p>An <strong>bold</strong> and <em>italic</em> and <a href="https://x.com">link</a>.</p>')
+    assert body == "An **bold** and *italic* and [link](https://x.com)."
+
+
+def test_md_blockquote_prefixes_lines():
+    assert _md("<blockquote><p>quoted line</p></blockquote><p>after</p>") == "> quoted line\n\nafter"
+
+
+def test_md_list_items_become_dashes():
+    assert _md("<ul><li>one</li><li>two</li></ul>") == "- one\n- two"
+
+
+def test_md_plain_text_without_tags():
+    assert _md("just text") == "just text"
 
 
 def test_select_preview_image_reads_og_image():
@@ -184,7 +219,7 @@ async def test_enrich_recovers_body_for_media_post():
     respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(200, html=POST_PAGE_HTML))
     async with httpx.AsyncClient() as client:
         await enrich_post(client, post)
-    assert post["selftext"] == "Recovered body line one.\nLine two."
+    assert post["selftext"] == "Recovered body line one.\n\nLine two."
 
 
 @respx.mock
@@ -193,7 +228,7 @@ async def test_enrich_recovers_body_for_text_post():
     respx.get("https://old.reddit.com/r/x/comments/txt/t/").mock(return_value=Response(200, html=POST_PAGE_HTML))
     async with httpx.AsyncClient() as client:
         await enrich_post(client, post)
-    assert post["selftext"] == "Recovered body line one.\nLine two."
+    assert post["selftext"] == "Recovered body line one.\n\nLine two."
 
 
 @respx.mock


### PR DESCRIPTION
## Контекст

Тела постов приходили в Telegram «слипшимися»: абзацы без пустых строк, потеряна разметка (жирный/ссылки). Регресс появился при переходе со скрейпинга JSON на old.reddit HTML (`b04c9b1`): раньше `selftext` был сырым markdown (из JSON) и красиво форматировался через `_md_to_telegram_html`, а после — извлекался через `md.get_text("\n")`, который схлопывает абзацы `<p>` в один перевод строки и стирает разметку.

## Изменения

- Добавлен `_html_to_markdown` — восстанавливает markdown из отрендеренного `div.md`: `<p>` → пустая строка между абзацами, `<br>` → перевод строки (soft breaks), `<strong>/<b>`, `<em>/<i>`, `<a href>`, `<blockquote>`, списки, заголовки, `<code>` → соответствующий markdown.
- Оба места извлечения тела (`_parse_thing` в листинге и `_select_selftext` на странице) используют новый `_selftext_from_md`.
- Дальше весь существующий пайплайн (`_md_to_telegram_html`, разбиение на сообщения, пустые строки) форматирует тело как до перехода на HTML.

## Тесты

Обновлены ожидания (абзацы теперь разделяются пустой строкой), добавлено 6 тестов конвертера (абзацы, soft breaks, эмфазис/ссылки, blockquote, списки, плейнтекст). Вся сюита — 150 passed, `ruff` чистый.

## Нюанс

Фикс применяется на этапе скрейпа, поэтому улучшенное форматирование получат новые (и ре-скрейпленные) посты; уже сохранённые тела остаются в старом виде.