### PR TITLE
Fetch og:image for every link post, not only when the listing had a thumbnail

### DIFF
--- a/src/scraper/reddit.py
+++ b/src/scraper/reddit.py
@@ -245,7 +245,9 @@ async def enrich_post(client: httpx.AsyncClient, post: dict) -> None:
     post instead of on every scrape.
     """
     needs_gallery = post["post_type"] == "gallery"
-    needs_preview = post["post_type"] == "link" and bool(post.get("preview_url"))
+    # Try the page's og:image for every link post: old.reddit sometimes omits the listing
+    # thumbnail even when the post has a large preview, so don't gate on preview_url being set.
+    needs_preview = post["post_type"] == "link"
     needs_body = not post.get("selftext")
     if not (needs_gallery or needs_preview or needs_body):
         return

--- a/tests/test_reddit_extended.py
+++ b/tests/test_reddit_extended.py
@@ -300,13 +300,14 @@ async def test_enrich_keeps_thumbnail_when_og_image_missing():
 
 
 @respx.mock
-async def test_enrich_link_without_preview_skips_fetch():
-    # A link post with no listing thumbnail and an existing body needs no page fetch.
-    route = respx.get(COMMENTS_URL).mock(return_value=Response(500))
+async def test_enrich_link_gets_og_image_without_listing_thumbnail():
+    # old.reddit may omit the listing thumbnail even when the post has a large preview:
+    # enrich must still fetch the page and pull og:image, so preview_url isn't left empty.
     post = {**SAMPLE_POST, "post_type": "link", "selftext": "x", "preview_url": None}
+    respx.get(COMMENTS_URL).mock(return_value=Response(200, html=PREVIEW_PAGE_HTML))
     async with httpx.AsyncClient() as client:
         await enrich_post(client, post)
-    assert not route.called
+    assert post["preview_url"] == "https://external-preview.redd.it/big.jpg?width=1080&s=SIG"
 
 
 # --- fetch_fresh_hls_url ---


### PR DESCRIPTION
## Контекст

Link-пост (r/news → nbcnews.com «Arizona toddler declared dead...») пришёл без картинки, хотя на Reddit превью есть. В БД `preview_url = None`, при этом пост скрейплен уже новым кодом.

Причина — гейт в `enrich_post`:
```python
needs_preview = post["post_type"] == "link" and bool(post.get("preview_url"))
```
og:image со страницы поста брался только если в листинге old.reddit уже был thumbnail. Для этого поста листинг thumbnail не отдал (`_parse_thing` → `preview_url = None`), поэтому og:image не извлекался — **хотя страница всё равно загружалась** (для тела) и og:image там был. Без превью `_publish_link` уходит в текстовое сообщение.

## Изменения

- `needs_preview = post["post_type"] == "link"` — для link-постов og:image берётся всегда, без гейта на listing-thumbnail. Лишних запросов почти нет: страница у link-постов и так грузится (тело обычно пустое). Если og:image нет — `preview_url` остаётся прежним.

## Тесты

Заменён тест «link без preview пропускает фетч» на «link без listing-thumbnail всё равно получает og:image». Вся сюита — 156 passed, `ruff` чистый.

## Нюанс

Фикс на этапе скрейпа — применяется к новым link-постам; уже сохранённые без preview_url остаются как есть.