### PR TITLE
Drop undownloadable videos quietly instead of a link-only notice

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -122,6 +122,14 @@ async def _publish_comments_delayed(config, poller: "UpdatePoller", post: dict, 
         logger.warning("Failed to publish comments for %s", post["reddit_id"], exc_info=True)
 
 
+async def _drop_silently(post: dict, reason: str) -> bool:
+    """Mark a post handled without any Telegram notice — used when a notice adds no value,
+    e.g. an undownloadable v.redd.it video that Reddit itself has removed/blocked."""
+    logger.warning("%s %s — dropping without notice", reason, post["reddit_id"])
+    await mark_as_published(post["reddit_id"], 0)
+    return False
+
+
 async def _drop_with_notice(config, post: dict, reason: str) -> bool:
     """Mark a post handled but send a link-only notice so it isn't silently lost."""
     logger.warning("%s %s — sending link-only fallback", reason, post["reddit_id"])
@@ -168,7 +176,9 @@ async def publish_one(config, poller: "UpdatePoller") -> bool | None:
         if media_path:
             media_path = await asyncio.get_event_loop().run_in_executor(None, compress_video, media_path)
         if media_path is None:
-            return await _drop_with_notice(config, post, "Video download/compress failed for")
+            # Undownloadable v.redd.it videos are usually removed/blocked upstream — a link-only
+            # notice is noise, so drop the post quietly instead.
+            return await _drop_silently(post, "Video download/compress failed for")
     elif post["post_type"] == "gallery" and post.get("media_urls"):
         paths = [await download_image(url) for url in post["media_urls"]]
         media_paths = [p for p in paths if p is not None] or None

--- a/tests/test_main_publish_one.py
+++ b/tests/test_main_publish_one.py
@@ -85,6 +85,39 @@ async def test_publish_one_sends_notice_when_media_download_fails(monkeypatch):
     assert notices == ["t3_lnk"]  # image posts that fail to download still send their link
 
 
+async def test_publish_one_video_download_failure_drops_without_notice(monkeypatch):
+    notices: list = []
+    published: dict = {}
+
+    async def fake_get(limit=None, max_age_hours=24):
+        return [{**LINK_POST, "post_type": "video", "video_url": "https://v.redd.it/x/DASH_720.mp4"}]
+
+    async def fake_fresh_hls(_config, _rid):
+        return None
+
+    async def fake_dl_video(_url, hls_url=None):
+        return None  # undownloadable video
+
+    async def fake_notice(_config, post):
+        notices.append(post["reddit_id"])
+        return 5
+
+    async def fake_mark(reddit_id, msg_id):
+        published[reddit_id] = msg_id
+
+    monkeypatch.setattr(main, "get_unpublished_posts", fake_get)
+    monkeypatch.setattr(main, "fetch_fresh_hls_url", fake_fresh_hls)
+    monkeypatch.setattr(main, "download_video_direct", fake_dl_video)
+    monkeypatch.setattr(main, "publish_failed_notice", fake_notice)
+    monkeypatch.setattr(main, "mark_as_published", fake_mark)
+
+    result = await main.publish_one(CONFIG, UpdatePoller(CONFIG))
+
+    assert result is False
+    assert notices == []  # no link-only notice for an undownloadable video
+    assert published == {"t3_lnk": 0}  # still marked handled so it isn't retried forever
+
+
 async def test_publish_one_downloads_link_preview_and_passes_photo_path(monkeypatch):
     captured: dict = {}
     cleaned: list = []


### PR DESCRIPTION
## Контекст

Видео-пост (v.redd.it) не смог скачаться и прислал fallback-уведомление «Не удалось опубликовать пост» со ссылками. Такие видео на Reddit обычно удалены/заблокированы (например клипы на r/LivestreamFail с ботом-зеркалом), само видео и на сайте «cannot be played». HLS-фрагменты приходят пустыми, а `DASH_720.mp4` отдаёт 403. Ссылка в уведомлении для такого поста бесполезна — это шум.

## Изменения

- Добавлен `_drop_silently(post, reason)` — помечает пост обработанным без Telegram-уведомления.
- В `publish_one` при неудаче скачивания/сжатия **видео** (`post_type == "video"`) используется тихий пропуск вместо `_drop_with_notice`.
- Остальные типы (image/gif/gallery, link-video, ошибка публикации) по-прежнему шлют link-only уведомление, чтобы пост не терялся молча.

## Тесты

+1 тест: видео с провалом скачивания не шлёт уведомление, но помечается обработанным (не ретраится вечно). Вся сюита — 157 passed, `ruff` чистый.